### PR TITLE
Fix manganelo grabber downloading (undesired) multiple chapters

### DIFF
--- a/grabber/manganelo.go
+++ b/grabber/manganelo.go
@@ -121,12 +121,14 @@ func (m Manganelo) FetchTitle() (string, error) {
 // FetchChapters returns a slice of chapters
 func (m Manganelo) FetchChapters() (chapters Filterables, errs []error) {
 	m.rows.Each(func(i int, s *goquery.Selection) {
-		re := regexp.MustCompile(`(\d+\.?\d*)`)
-		num := re.FindString(s.Find("a").Text())
+		re := regexp.MustCompile(`Chapter\s*(\d+\.?\d*)`)
+		chap := re.FindStringSubmatch(s.Find("a").Text())
 		// if the chapter has no number, we skip it (usually it's an announcement from the site)
-		if num == "" {
+		if len(chap) == 0 {
 			return
 		}
+
+		num := chap[1]
 		number, err := strconv.ParseFloat(num, 64)
 		if err != nil {
 			errs = append(errs, err)

--- a/makefile
+++ b/makefile
@@ -39,6 +39,7 @@ grabber/manganelo:
 	go run . https://mangakakalot.com/manga/vd921334 7
 	go run . https://ww5.manganelo.tv/manga/manga-aa951409 3
 	go run . http://manganelos.com/manga/dont-pick-up-what-youve-thrown-away 10-12 --bundle
+	go run . https://readmangabat.com/read-ov357862 23
 	go run . https://chapmanganato.com/manga-aa951409 50
 	go run . https://h.mangabat.com/read-tc397521 5
 	go run . https://mangajar.com/manga/chainsaw-man-absTop-abs3bof 23


### PR DESCRIPTION
Some series in manganelo-like sites may have their title with `Vol X`, which was resulting in downloading all of these volumes when you where trying to download chapter X.

Instead of searching for numbers only, the change searches for "Chapter N" in the title, ignoring anything that's not passing that expression.

Since manganelo-like sites all have the "Chapter N" somewhere in their title (except for some rare cases like announcements, which I'd say we can ignore them safely), this should be safe for 99.99% of the cases.

refs #17