### PR TITLE
Add tcbscans.com & asurascans support

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,15 +15,15 @@ Supported sites
 ---------------
 
 - [Inmanga](https://inmanga.com)
-- [LeviatanScans](https://leviatanscans.com)
+- [lscomic.com](https://lscomic.com/)
 - [MangaBat](https://readmangabat.com)
 - [Mangadex](https://mangadex.org)
-- [MangaJar](https://mangajar.com)
+- [MangaJar](https://mangajar.pro)
 - [Mangakakalot](https://mangakakalot.com)
 - [Manganato](https://manganato.com) (aka manganelo.com)
 - [Manganelo.tv](https://ww5.manganelo.tv)
 - [Manganelos](http://manganelos.com)
-- [TCBScans](https://www.tcbscans.net)
+- TCBScans ([net](https://www.tcbscans.net), [org](https://www.tcbscans.org), [com](https://tcbscans.com))
 
 If you'd like support for a specific site, [create a new issue][issues] or even
 a PR with the changes.

--- a/grabber/manganelo.go
+++ b/grabber/manganelo.go
@@ -46,8 +46,6 @@ func (m *Manganelo) Test() (bool, error) {
 		"#examples div.chapter-list .row",
 		// mangakakalot style
 		"div.chapter-list .row",
-		// mangajar style (required when there are no more pages)
-		"article.chaptersList li.chapter-item",
 	}
 
 	// mangajar has ajax pagination

--- a/grabber/plainhtml.go
+++ b/grabber/plainhtml.go
@@ -65,6 +65,15 @@ func (m *PlainHTML) Test() (bool, error) {
 			Link:         "a",
 			Image:        "#readerarea img.ts-main-image",
 		},
+		// mangajar.pro
+		{
+			Title:        "h1 .post-name",
+			Rows:         "article.chaptersList li.chapter-item",
+			Chapter:      ".chapter-title",
+			ChapterTitle: "a",
+			Link:         "a",
+			Image:        "#chapter-slider .carousel-item img",
+		},
 	}
 
 	// for the same priority reasons, we need to iterate over the selectors
@@ -87,7 +96,7 @@ func (m *PlainHTML) Test() (bool, error) {
 
 // Ttitle returns the manga title
 func (m PlainHTML) FetchTitle() (string, error) {
-	title := m.doc.Find("h1")
+	title := m.doc.Find(m.site.Title)
 
 	return title.Text(), nil
 }

--- a/grabber/plainhtml.go
+++ b/grabber/plainhtml.go
@@ -1,0 +1,160 @@
+package grabber
+
+import (
+	"regexp"
+	"strconv"
+	"strings"
+
+	"github.com/PuerkitoBio/goquery"
+	"github.com/elboletaire/manga-downloader/http"
+	"github.com/fatih/color"
+)
+
+// PlainHTML is a grabber for any plain HTML page (with no ajax pagination whatsoever)
+type PlainHTML struct {
+	*Grabber
+	doc  *goquery.Document
+	rows *goquery.Selection
+}
+
+// PlainHTMLChapter represents a PlainHTML Chapter
+type PlainHTMLChapter struct {
+	Chapter
+	URL string
+}
+
+// Test returns true if the URL is a valid grabber URL
+func (m *PlainHTML) Test() (bool, error) {
+	body, err := http.Get(http.RequestParams{
+		URL: m.URL,
+	})
+	if err != nil {
+		return false, err
+	}
+	m.doc, err = goquery.NewDocumentFromReader(body)
+	if err != nil {
+		return false, err
+	}
+
+	// order is important, since some sites have very similar selectors
+	selectors := []string{
+		// tcbscans.com
+		"main .mx-auto .grid .col-span-2 a",
+	}
+
+	// for the same priority reasons, we need to iterate over the selectors
+	// using a simple `,` joining all selectors would return missmatches
+	for _, selector := range selectors {
+		rows := m.doc.Find(selector)
+		if rows.Length() > 0 {
+			m.rows = rows
+			break
+		}
+	}
+
+	if m.rows == nil {
+		return false, nil
+	}
+
+	return m.rows.Length() > 0, nil
+}
+
+// Ttitle returns the manga title
+func (m PlainHTML) FetchTitle() (string, error) {
+	title := m.doc.Find("h1")
+
+	return title.Text(), nil
+}
+
+// FetchChapters returns a slice of chapters
+func (m PlainHTML) FetchChapters() (chapters Filterables, errs []error) {
+	m.rows.Each(func(i int, s *goquery.Selection) {
+		// we need to get the chapter number from the title
+		re := regexp.MustCompile(`Chapter\s*(\d+\.?\d*)`)
+		chap := re.FindStringSubmatch(s.Find(".font-bold").Text())
+		// if the chapter has no number, we skip it (these are usually site announcements)
+		if len(chap) == 0 {
+			return
+		}
+
+		num := chap[1]
+		number, err := strconv.ParseFloat(num, 64)
+		if err != nil {
+			errs = append(errs, err)
+			return
+		}
+		u := s.AttrOr("href", "")
+		if !strings.HasPrefix(u, "http") {
+			u = m.BaseUrl() + u
+		}
+		chapter := &ManganeloChapter{
+			Chapter{
+				Number: number,
+				Title:  s.Find(".text-gray-500").Text(),
+			},
+			u,
+		}
+
+		chapters = append(chapters, chapter)
+	})
+
+	return
+}
+
+// FetchChapter fetches a chapter and its pages
+func (m PlainHTML) FetchChapter(f Filterable) (*Chapter, error) {
+	mchap := f.(*ManganeloChapter)
+	body, err := http.Get(http.RequestParams{
+		URL: mchap.URL,
+	})
+	if err != nil {
+		return nil, err
+	}
+	defer body.Close()
+	doc, err := goquery.NewDocumentFromReader(body)
+	if err != nil {
+		return nil, err
+	}
+
+	pimages := getPlainHTMLImageURL(doc)
+
+	chapter := &Chapter{
+		Title:      f.GetTitle(),
+		Number:     f.GetNumber(),
+		PagesCount: int64(len(pimages)),
+		Language:   "en",
+	}
+
+	for i, img := range pimages {
+		if img == "" {
+			// this error is not critical and is not from our side, so just log it out
+			color.Yellow("page %d of %s has no URL to fetch from 😕 (will be ignored)", i, chapter.GetTitle())
+			continue
+		}
+		if !strings.HasPrefix(img, "http") {
+			img = m.BaseUrl() + img
+		}
+		page := Page{
+			Number: int64(i),
+			URL:    img,
+		}
+		chapter.Pages = append(chapter.Pages, page)
+	}
+
+	return chapter, nil
+}
+
+func getPlainHTMLImageURL(doc *goquery.Document) []string {
+	// images are inside picture objects
+	pimages := doc.Find("picture img")
+	imgs := []string{}
+	pimages.Each(func(i int, s *goquery.Selection) {
+		src := s.AttrOr("src", "")
+		if src == "" || strings.HasPrefix(src, "data:image") {
+			src = s.AttrOr("data-src", "")
+		}
+		imgs = append(imgs, src)
+	})
+
+	return imgs
+}

--- a/grabber/site.go
+++ b/grabber/site.go
@@ -70,6 +70,7 @@ func (g *Grabber) IdentifySite() (Site, []error) {
 		&Mangadex{Grabber: g},
 		&Tcb{Grabber: g},
 		&Manganelo{Grabber: g},
+		&PlainHTML{Grabber: g},
 	}
 	var errs []error
 

--- a/grabber/site.go
+++ b/grabber/site.go
@@ -66,11 +66,11 @@ type Site interface {
 // IdentifySite returns the site passing the Test() for the specified url
 func (g *Grabber) IdentifySite() (Site, []error) {
 	sites := []Site{
+		&PlainHTML{Grabber: g},
 		&Inmanga{Grabber: g},
 		&Mangadex{Grabber: g},
 		&Tcb{Grabber: g},
 		&Manganelo{Grabber: g},
-		&PlainHTML{Grabber: g},
 	}
 	var errs []error
 

--- a/makefile
+++ b/makefile
@@ -33,16 +33,14 @@ else
 	go test -v ./...
 endif
 
-grabber: grabber/manganelo grabber/inmanga grabber/mangadex grabber/tcb
+grabber: grabber/manganelo grabber/inmanga grabber/mangadex grabber/tcb grabber/html
 
 grabber/manganelo:
 	go run . https://mangakakalot.com/manga/vd921334 7
 	go run . https://ww5.manganelo.tv/manga/manga-aa951409 3
-	go run . http://manganelos.com/manga/dont-pick-up-what-youve-thrown-away 10-12 --bundle
 	go run . https://readmangabat.com/read-ov357862 23
 	go run . https://chapmanganato.com/manga-aa951409 50
 	go run . https://h.mangabat.com/read-tc397521 5
-	go run . https://mangajar.com/manga/chainsaw-man-absTop-abs3bof 23
 
 grabber/inmanga:
 	go run . https://inmanga.com/ver/manga/One-Piece/dfc7ecb5-e9b3-4aa5-a61b-a498993cd935 1
@@ -52,4 +50,9 @@ grabber/mangadex:
 
 grabber/tcb:
 	go run . https://www.tcbscans.net/manga/one-piece/ 5
-	go run . https://en.leviatanscans.com/home/manga/i-became-the-male-leads-adopted-daughter/ 5
+	go run . https://lscomic.com/manga/peerless-dad/ 285
+
+grabber/html:
+	go run . https://tcbscans.com/mangas/5/one-piece 1100
+	go run . https://asuratoon.com/manga/0435219386-return-of-the-sss-class-ranker/ 85
+	go run . https://mangajar.pro/manga/haite-kudasai-takamine-san 43


### PR DESCRIPTION
The grabber is almost a copy-paste from manganelo grabber. I named it `PlainHTML` with the idea to unify some grabbers into this one, since adding support in the manganelo grabber to tcbscans didn't make much sense, and the existing tcbscans grabber parses the site in a different way (uses ajax) not as reusable as the manganelo one. 

I'll create a new issue to try to track this grabber unification. (done https://github.com/elboletaire/manga-downloader/issues/26)

refs #1 