### PR TITLE
Avoid downloading already existing chapters

### DIFF
--- a/grabber/filterable.go
+++ b/grabber/filterable.go
@@ -1,6 +1,7 @@
 package grabber
 
 import (
+	"slices"
 	"sort"
 
 	"github.com/elboletaire/manga-downloader/ranges"
@@ -45,6 +46,15 @@ func (f Filterables) FilterRanges(rngs []ranges.Range) Filterables {
 			return c.GetNumber() >= float64(r.Begin) && c.GetNumber() <= float64(r.End)
 		})...)
 	}
+
+	return chaps
+}
+
+// FilterList returns the Filterables, without the ones with a Number matched in specified blacklist
+func (f Filterables) FilterOutList(blacklist []float64) Filterables {
+	chaps := f.Filter(func(c Filterable) bool {
+		return ! slices.Contains(blacklist, c.GetNumber())
+	})
 
 	return chaps
 }

--- a/grabber/site.go
+++ b/grabber/site.go
@@ -33,6 +33,8 @@ type Settings struct {
 	Range string
 	// OutputDir is the output directory for the downloaded files
 	OutputDir string
+	// ForceDownload forces chapter download even if it is found in local folder
+	ForceDownload bool
 }
 
 // MaxConcurrency is the max concurrency for a site

--- a/packer/filename.go
+++ b/packer/filename.go
@@ -37,10 +37,15 @@ func NewFilenameFromTemplate(templ string, parts FilenameTemplateParts) (string,
 
 // NewChapterFileTemplateParts returns a new FilenameTemplateParts from a title and a chapter
 func NewChapterFileTemplateParts(title string, chapter *grabber.Chapter) FilenameTemplateParts {
+	return NewChapterFileTemplatePartsFromParts(title, chapter.GetNumber(), chapter.GetTitle())
+}
+
+// NewChapterFileTemplateParts returns a new FilenameTemplateParts from a series title, a number and a chapter title
+func NewChapterFileTemplatePartsFromParts(series string, number float64, title string) FilenameTemplateParts {
 	return FilenameTemplateParts{
-		Series: SanitizeFilename(title),
-		Number: strings.Replace(fmt.Sprintf("%.1f", chapter.GetNumber()), ".0", "", 1),
-		Title:  SanitizeFilename(chapter.GetTitle()),
+		Series: SanitizeFilename(series),
+		Number: strings.Replace(fmt.Sprintf("%.1f", number), ".0", "", 1),
+		Title:  SanitizeFilename(title),
 	}
 }
 

--- a/packer/pack.go
+++ b/packer/pack.go
@@ -3,6 +3,7 @@ package packer
 import (
 	"fmt"
 	"path/filepath"
+	"os"
 
 	"github.com/elboletaire/manga-downloader/downloader"
 	"github.com/elboletaire/manga-downloader/grabber"
@@ -33,6 +34,15 @@ func PackBundle(outputdir string, s grabber.Site, chapters []*DownloadedChapter,
 		Number: rng,
 		Title:  "bundle",
 	}, files)
+}
+
+func CheckAlreadyDownloaded(outputdir string, template string, title string, number float64, chapterTitle string) (bool) {
+	filename, _ := NewFilenameFromTemplate(template, NewChapterFileTemplatePartsFromParts(title, number, chapterTitle))
+	filename += ".cbz"
+	if _, err := os.Stat(filepath.Join(outputdir, filename)); err == nil {
+		return true
+	}
+	return false
 }
 
 func pack(outputdir, template, title string, parts FilenameTemplateParts, files []*downloader.File) (string, error) {


### PR DESCRIPTION
Some chapters may have been previously downloaded, or a previous download session may have been interrupted. In any case, the user would rather not download again previously pulled chapters, and only download missing chapters.

The download folder is now scanned for chapters that would be created, and detected chapters are skipped.
The detection is based on file name, and the chapter number.

A new run flag is introduced to force download anyways.

Note: bundle download remains unchanged.