### PR TITLE
add rate limiter for mangadex

### DIFF
--- a/grabber/inmanga.go
+++ b/grabber/inmanga.go
@@ -3,17 +3,20 @@ package grabber
 import (
 	"encoding/json"
 	"fmt"
-	"regexp"
-	"strconv"
-
 	"github.com/PuerkitoBio/goquery"
 	"github.com/elboletaire/manga-downloader/http"
+	"regexp"
+	"strconv"
 )
 
 // Inmanga is a grabber for inmanga.com
 type Inmanga struct {
 	*Grabber
 	title string
+}
+
+func NewInmanga(g *Grabber) *Inmanga {
+	return &Inmanga{Grabber: g}
 }
 
 // InmangaChapter is a chapter representation from InManga

--- a/grabber/plainhtml.go
+++ b/grabber/plainhtml.go
@@ -1,13 +1,12 @@
 package grabber
 
 import (
-	"regexp"
-	"strconv"
-	"strings"
-
 	"github.com/PuerkitoBio/goquery"
 	"github.com/elboletaire/manga-downloader/http"
 	"github.com/fatih/color"
+	"regexp"
+	"strconv"
+	"strings"
 )
 
 // PlainHTML is a grabber for any plain HTML page (with no ajax pagination whatsoever)
@@ -16,6 +15,10 @@ type PlainHTML struct {
 	doc  *goquery.Document
 	rows *goquery.Selection
 	site SiteSelector
+}
+
+func NewPlainHTML(g *Grabber) *PlainHTML {
+	return &PlainHTML{Grabber: g}
 }
 
 type SiteSelector struct {

--- a/grabber/site.go
+++ b/grabber/site.go
@@ -2,13 +2,12 @@ package grabber
 
 import (
 	"errors"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 	"net/url"
 	"regexp"
 	"strconv"
 	"strings"
-
-	"github.com/spf13/cobra"
-	"github.com/spf13/pflag"
 )
 
 // Grabber is the base struct for all grabbers/sites
@@ -68,10 +67,10 @@ type Site interface {
 // IdentifySite returns the site passing the Test() for the specified url
 func (g *Grabber) IdentifySite() (Site, []error) {
 	sites := []Site{
-		&PlainHTML{Grabber: g},
-		&Inmanga{Grabber: g},
-		&Mangadex{Grabber: g},
-		&Tcb{Grabber: g},
+		NewPlainHTML(g),
+		NewInmanga(g),
+		NewMangadex(g),
+		NewTcb(g),
 	}
 	var errs []error
 

--- a/grabber/tcb.go
+++ b/grabber/tcb.go
@@ -1,14 +1,13 @@
 package grabber
 
 import (
+	"github.com/PuerkitoBio/goquery"
+	"github.com/elboletaire/manga-downloader/http"
+	"github.com/fatih/color"
 	"net/url"
 	"regexp"
 	"strconv"
 	"strings"
-
-	"github.com/PuerkitoBio/goquery"
-	"github.com/elboletaire/manga-downloader/http"
-	"github.com/fatih/color"
 )
 
 // Tcb is a grabber for tcbscans.com (and possibly other wordpress sites)
@@ -16,6 +15,10 @@ type Tcb struct {
 	*Grabber
 	chaps *goquery.Selection
 	title string
+}
+
+func NewTcb(g *Grabber) *Tcb {
+	return &Tcb{Grabber: g}
 }
 
 // TcbChapter is a chapter for TCBScans


### PR DESCRIPTION
Downloading full mangas from mangadex eventually ends up giving a 429 error after about 40 chapters.
This is due to a rate limit on the `/at-home/` endpoint of the mangadex api as seen here https://api.mangadex.org/docs/2-limitations/#endpoint-specific-rate-limits.

as stated in the mangadex api documentation, they have a rate limit of 40 requests per minute for the `/at-home` endpoint, this PR adds a ratelimiter for the Mangadex site handler to respect that limit.