### PR TITLE
feat: parse decimal chapter range

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -5,6 +5,11 @@ package cmd
 
 import (
 	"fmt"
+	"os"
+	"regexp"
+	"strings"
+	"sync"
+
 	"github.com/elboletaire/manga-downloader/downloader"
 	"github.com/elboletaire/manga-downloader/grabber"
 	"github.com/elboletaire/manga-downloader/packer"
@@ -12,10 +17,6 @@ import (
 	"github.com/fatih/color"
 	"github.com/manifoldco/promptui"
 	"github.com/spf13/cobra"
-	"os"
-	"regexp"
-	"strings"
-	"sync"
 
 	cc "github.com/ivanpirog/coloredcobra"
 )

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -5,11 +5,6 @@ package cmd
 
 import (
 	"fmt"
-	"os"
-	"regexp"
-	"strings"
-	"sync"
-
 	"github.com/elboletaire/manga-downloader/downloader"
 	"github.com/elboletaire/manga-downloader/grabber"
 	"github.com/elboletaire/manga-downloader/packer"
@@ -17,6 +12,10 @@ import (
 	"github.com/fatih/color"
 	"github.com/manifoldco/promptui"
 	"github.com/spf13/cobra"
+	"os"
+	"regexp"
+	"strings"
+	"sync"
 
 	cc "github.com/ivanpirog/coloredcobra"
 )
@@ -103,7 +102,7 @@ Note arguments aren't really positional, you can specify them in any order:
 				os.Exit(0)
 			}
 
-			rngs = []ranges.Range{{Begin: 1, End: int64(lastChapter)}}
+			rngs = []ranges.Range{{Begin: 1, End: lastChapter}}
 		} else {
 			// ranges parsing
 			settings.Range = getRangesArg(args)

--- a/ranges/parser.go
+++ b/ranges/parser.go
@@ -7,25 +7,25 @@ import (
 
 // Range represents a range of numbers
 type Range struct {
-	Begin int64
-	End   int64
+	Begin float64
+	End   float64
 }
 
 // Parse parses a string and returns a slice of ranges
 func Parse(rnge string) (rngs []Range, err error) {
 	co := strings.Split(rnge, ",")
-	var cur int64
-	var begin int64
-	var end int64
+	var cur float64
+	var begin float64
+	var end float64
 
 	for _, part := range co {
 		in := strings.Split(part, "-")
-		if cur, err = strconv.ParseInt(in[0], 10, 64); err != nil {
+		if cur, err = strconv.ParseFloat(in[0], 64); err != nil {
 			return
 		}
 		if len(in) == 2 {
 			begin = cur
-			if end, err = strconv.ParseInt(in[1], 10, 64); err != nil {
+			if end, err = strconv.ParseFloat(in[1], 64); err != nil {
 				return
 			}
 		}


### PR DESCRIPTION
Currently the CLI tool doesn't accept chapters that are decimal in values ex. `76.4`.
There are quite a few mangas on mangadex that have chapters and volumes with a decimal values.

This PR allows downloading chapters and ranges that include a decimal value

This fixes: #57