### PR TITLE
feat: don't overwrite duplicate chapters

### DIFF
--- a/packer/cbz.go
+++ b/packer/cbz.go
@@ -14,7 +14,7 @@ func ArchiveCBZ(filename string, files []*downloader.File, progress func(page, p
 	if len(files) == 0 {
 		return errors.New("no files to pack")
 	}
-	buff, err := os.Create(filename)
+	buff, err := os.OpenFile(filename, os.O_RDWR|os.O_CREATE|os.O_EXCL, 0666)
 	if err != nil {
 		return err
 	}

--- a/packer/filename.go
+++ b/packer/filename.go
@@ -17,6 +17,8 @@ type FilenameTemplateParts struct {
 	Number string
 	// Title represents the chapter title (e.g. "The Beginning")
 	Title string
+	// Version placeholder appended to the title in case of duplicate filenames (e.g. "3")
+	Version int
 }
 
 // FilenameTemplateDefault is the default filename template
@@ -24,6 +26,9 @@ const FilenameTemplateDefault = "{{.Series}} {{.Number}} - {{.Title}}"
 
 // NewFilenameFromTemplate returns a new filename from a series title, a chapter and a template
 func NewFilenameFromTemplate(templ string, parts FilenameTemplateParts) (string, error) {
+	if parts.Version > 1 {
+		parts.Title = fmt.Sprintf("%s v%d", parts.Title, parts.Version)
+	}
 	tmpl, err := template.New("filename").Parse(templ)
 	if err != nil {
 		return "", err

--- a/packer/filename.go
+++ b/packer/filename.go
@@ -22,13 +22,10 @@ type FilenameTemplateParts struct {
 }
 
 // FilenameTemplateDefault is the default filename template
-const FilenameTemplateDefault = "{{.Series}} {{.Number}} - {{.Title}}"
+const FilenameTemplateDefault = "{{.Series}} {{.Number}} - {{.Title}}{{if gt .Version 1}} v{{.Version}}{{end}}"
 
 // NewFilenameFromTemplate returns a new filename from a series title, a chapter and a template
 func NewFilenameFromTemplate(templ string, parts FilenameTemplateParts) (string, error) {
-	if parts.Version > 1 {
-		parts.Title = fmt.Sprintf("%s v%d", parts.Title, parts.Version)
-	}
 	tmpl, err := template.New("filename").Parse(templ)
 	if err != nil {
 		return "", err


### PR DESCRIPTION
when downloading from mangadex you can usually not choose which scanlation group to download for a specific chapter, This PR changes writing the chapter to a file by not overwriting it if it already exists, rather it appends `v1`, `v2`, `v3` ...etc for every duplicate.