### PR TITLE
Fixed single image strategy for TCB

### DIFF
--- a/grabber/tcb.go
+++ b/grabber/tcb.go
@@ -158,15 +158,11 @@ func (t Tcb) FetchChapter(f Filterable) (*Chapter, error) {
 			continue
 		}
 
-		// Find image in this page
-		found := false
+		// Collect all images in this page
 		pageDoc.Find("div.reading-content img").Each(func(i int, s *goquery.Selection) {
-			if found {
-				return // Only take first image per page
-			}
 			u := strings.TrimSpace(s.AttrOr("data-src", s.AttrOr("src", "")))
 			if u == "" {
-				color.Yellow("page %d of %s has no URL to fetch from", pageNum+1, f.GetTitle())
+				color.Yellow("page %d of %s has an image with no URL to fetch from", pageNum+1, f.GetTitle())
 				return
 			}
 			if !strings.HasPrefix(u, "http") {
@@ -176,7 +172,6 @@ func (t Tcb) FetchChapter(f Filterable) (*Chapter, error) {
 				Number: int64(pageNum + 1),
 				URL:    u,
 			})
-			found = true
 		})
 	}
 


### PR DESCRIPTION
tcbscans.org now seems to have the entire chapter in a single page. With the existing code, it just seems to download the first image of the chapter before moving to the next chapter.
Changed the logic to download all images on the chapter page before moving to the next

Eg. https://www.tcbscans.org/manga/nano-machine/episode-257/