### PR TITLE
fix(grabbers): fix mangabuddy chapter list by using chapters API

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -25,7 +25,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: elboletaire/manga-downloader
+          images: omarim/manga-downloader
           # set latest tag for master branch
           tags: |
             type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', 'master') }}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -167,6 +167,7 @@ func Run(cmd *cobra.Command, args []string) {
 			wg := sync.WaitGroup{}
 			g := make(chan struct{}, s.GetMaxConcurrency().Chapters)
 			downloaded := grabber.Filterables{}
+			var mu sync.Mutex
 
 			for _, chap := range volChapters {
 				g <- struct{}{}
@@ -192,10 +193,12 @@ func Run(cmd *cobra.Command, args []string) {
 						return
 					}
 					bar.IncrBy(int(chapter.PagesCount))
+					mu.Lock()
 					downloaded = append(downloaded, &packer.DownloadedChapter{
 						Chapter: chapter,
 						Files:   files,
 					})
+					mu.Unlock()
 					<-g
 				}(chap)
 			}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -26,6 +26,9 @@ import (
 )
 
 var settings grabber.Settings
+var volumesStr string
+var volumeFile string
+var volumeFilenameTemplate string
 
 // rootCmd represents the base command when called without any subcommands
 var rootCmd = &cobra.Command{
@@ -78,6 +81,16 @@ func Run(cmd *cobra.Command, args []string) {
 		os.Exit(1)
 	}
 	s.InitFlags(cmd)
+
+	if volumesStr != "" && volumeFile != "" {
+		cerr(fmt.Errorf("--volumes and --volume-file are mutually exclusive"), "")
+	}
+	if (volumesStr != "" || volumeFile != "") && settings.Bundle {
+		cerr(fmt.Errorf("--volumes/--volume-file and --bundle are mutually exclusive"), "")
+	}
+	if (volumesStr != "" || volumeFile != "") && len(args) > 1 {
+		cerr(fmt.Errorf("--volumes/--volume-file and a chapter range argument are mutually exclusive"), "")
+	}
 
 	// fetch series title
 	title, err := s.FetchTitle()
@@ -342,6 +355,9 @@ func init() {
 	rootCmd.Flags().StringVarP(&settings.FilenameTemplate, "filename-template", "t", packer.FilenameTemplateDefault, "template for the resulting filename")
 	// set as persistent, so version command does not complain about the -o flag set via docker
 	rootCmd.PersistentFlags().StringVarP(&settings.OutputDir, "output-dir", "o", "./", "output directory for the downloaded files")
+	rootCmd.Flags().StringVar(&volumesStr, "volumes", "", `semicolon-delimited chapter ranges, one per volume (e.g. "1-8;9-17;18-25")`)
+	rootCmd.Flags().StringVar(&volumeFile, "volume-file", "", "path to a file with one chapter range per line, each line becoming one volume")
+	rootCmd.Flags().StringVar(&volumeFilenameTemplate, "volume-filename-template", packer.FilenameVolumeTemplateDefault, "template for volume output filenames")
 }
 
 func cerr(err error, prefix string) {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -108,6 +108,118 @@ func Run(cmd *cobra.Command, args []string) {
 
 	chapters = chapters.SortByNumber()
 
+	// volume mode: download and pack chapters into per-volume CBZ files
+	if volumesStr != "" || volumeFile != "" {
+		var volumeRanges [][]ranges.Range
+		if volumesStr != "" {
+			volumeRanges, err = ranges.ParseVolumes(volumesStr)
+		} else {
+			volumeRanges, err = ranges.ParseVolumesFile(volumeFile)
+		}
+		cerr(err, "Error parsing volumes: ")
+
+		blue := color.New(color.FgBlue)
+
+		for i, volRanges := range volumeRanges {
+			volNum := i + 1
+
+			volChapters := chapters.FilterRanges(volRanges)
+			if len(volChapters) == 0 {
+				color.Yellow("Vol.%02d: no chapters found in specified range, skipping", volNum)
+				continue
+			}
+
+			// pre-fetch page counts for progress bar total
+			totalPages := int64(0)
+			for _, chap := range volChapters {
+				chapter, err := s.FetchChapter(chap)
+				if err == nil && chapter != nil {
+					totalPages += chapter.PagesCount
+				}
+			}
+
+			// progress bar for this volume
+			p := mpb.New(
+				mpb.WithWidth(40),
+				mpb.WithOutput(color.Output),
+				mpb.WithAutoRefresh(),
+			)
+			volLabel := fmt.Sprintf("Vol.%02d", volNum)
+			bar := p.AddBar(totalPages*2,
+				mpb.PrependDecorators(
+					decor.Any(func(s decor.Statistics) string {
+						return blue.Sprintf("%-30s", volLabel)
+					}, decor.WCSyncWidthR),
+					decor.CountersNoUnit("%d/%d", decor.WC{C: decor.DextraSpace}),
+				),
+				mpb.AppendDecorators(
+					decor.Percentage(decor.WC{W: 4}),
+					decor.Any(func(s decor.Statistics) string {
+						if s.Current >= s.Total {
+							return blue.Sprintf(" bundling ")
+						}
+						return blue.Sprintf(" downloading")
+					}, decor.WC{W: 10}),
+				),
+			)
+
+			// download chapters concurrently
+			wg := sync.WaitGroup{}
+			g := make(chan struct{}, s.GetMaxConcurrency().Chapters)
+			downloaded := grabber.Filterables{}
+
+			for _, chap := range volChapters {
+				g <- struct{}{}
+				wg.Add(1)
+				go func(chap grabber.Filterable) {
+					defer wg.Done()
+					chapter, err := s.FetchChapter(chap)
+					if err != nil {
+						color.Red("- error fetching chapter %s: %s", chap.GetTitle(), err.Error())
+						<-g
+						return
+					}
+					files, err := downloader.FetchChapter(s, chapter, func(_ int, idx int, err error) {
+						if err != nil {
+							color.Red("- error downloading page %d: %s", idx+1, err.Error())
+						} else {
+							bar.IncrBy(1)
+						}
+					})
+					if err != nil {
+						color.Red("- error downloading chapter %s: %s", chapter.GetTitle(), err.Error())
+						<-g
+						return
+					}
+					bar.IncrBy(int(chapter.PagesCount))
+					downloaded = append(downloaded, &packer.DownloadedChapter{
+						Chapter: chapter,
+						Files:   files,
+					})
+					<-g
+				}(chap)
+			}
+			wg.Wait()
+			close(g)
+			p.Wait()
+
+			// sort and convert for packing
+			downloaded = downloaded.SortByNumber()
+			dc := make([]*packer.DownloadedChapter, 0, len(downloaded))
+			for _, d := range downloaded {
+				dc = append(dc, d.(*packer.DownloadedChapter))
+			}
+
+			filename, err := packer.PackVolume(settings.OutputDir, volumeFilenameTemplate, s, dc, volNum, func(_, _ int) {})
+			if err != nil {
+				color.Red(err.Error())
+				continue
+			}
+			fmt.Printf("- %s %s\n", color.GreenString("saved file"), color.HiBlackString(filename))
+		}
+		os.Exit(0)
+	}
+
 	var rngs []ranges.Range
 	// ranges argument is not provided
 	if len(args) == 1 {

--- a/docs/superpowers/plans/2026-04-04-volume-batching.md
+++ b/docs/superpowers/plans/2026-04-04-volume-batching.md
@@ -1,0 +1,662 @@
+# Volume Batching Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Allow users to batch downloaded chapters into per-volume CBZ files by specifying chapter ranges via `--volumes` flag or `--volume-file`.
+
+**Architecture:** Two new parsing functions in `ranges`, a new `Volume` field in `packer.FilenameTemplateParts` plus a `PackVolume` function, and a new volume download loop in `cmd/root.go` that reuses existing concurrency and packing infrastructure.
+
+**Tech Stack:** Go, goquery, mpb/v8 (progress bars), cobra (CLI flags)
+
+---
+
+### Task 1: ParseVolumes
+
+**Files:**
+- Modify: `ranges/parser.go`
+- Modify: `ranges/parser_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `ranges/parser_test.go`:
+
+```go
+func TestParseVolumes(t *testing.T) {
+	// basic three-volume split
+	vols, err := ParseVolumes("1-8;9-17;18-25")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(vols) != 3 {
+		t.Fatalf("expected 3 volumes, got %d", len(vols))
+	}
+	if vols[0][0].Begin != 1 || vols[0][0].End != 8 {
+		t.Error("expected volume 1 range 1-8")
+	}
+	if vols[1][0].Begin != 9 || vols[1][0].End != 17 {
+		t.Error("expected volume 2 range 9-17")
+	}
+	if vols[2][0].Begin != 18 || vols[2][0].End != 25 {
+		t.Error("expected volume 3 range 18-25")
+	}
+
+	// decimal chapter numbers
+	vols2, err := ParseVolumes("168.1-170;262.5")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if vols2[0][0].Begin != 168.1 || vols2[0][0].End != 170 {
+		t.Error("expected volume 1 range 168.1-170")
+	}
+	if vols2[1][0].Begin != 262.5 || vols2[1][0].End != 262.5 {
+		t.Error("expected volume 2 range 262.5-262.5")
+	}
+
+	// comma-separated chapters within a volume
+	vols3, err := ParseVolumes("1-8,10;9-17")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(vols3[0]) != 2 {
+		t.Errorf("expected volume 1 to have 2 ranges, got %d", len(vols3[0]))
+	}
+	if vols3[0][1].Begin != 10 || vols3[0][1].End != 10 {
+		t.Error("expected second range of volume 1 to be 10-10")
+	}
+
+	// invalid range returns error
+	_, err = ParseVolumes("abc")
+	if err == nil {
+		t.Error("expected error for invalid range")
+	}
+}
+```
+
+- [ ] **Step 2: Run the test to confirm it fails**
+
+```bash
+go test -v ./ranges/... -run TestParseVolumes
+```
+
+Expected: `FAIL` — `ParseVolumes` undefined.
+
+- [ ] **Step 3: Implement ParseVolumes**
+
+Add to the bottom of `ranges/parser.go`:
+
+```go
+// ParseVolumes parses a semicolon-delimited string of chapter ranges into
+// a slice of range-slices, where each inner slice represents one volume.
+// Commas within a segment work the same as in Parse (e.g. "1-8,10" is valid).
+func ParseVolumes(s string) ([][]Range, error) {
+	segments := strings.Split(s, ";")
+	volumes := make([][]Range, 0, len(segments))
+	for _, seg := range segments {
+		seg = strings.TrimSpace(seg)
+		if seg == "" {
+			continue
+		}
+		rngs, err := Parse(seg)
+		if err != nil {
+			return nil, err
+		}
+		volumes = append(volumes, rngs)
+	}
+	return volumes, nil
+}
+```
+
+- [ ] **Step 4: Run the test to confirm it passes**
+
+```bash
+go test -v ./ranges/... -run TestParseVolumes
+```
+
+Expected: `PASS`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add ranges/parser.go ranges/parser_test.go
+git commit -m "feat(ranges): add ParseVolumes for semicolon-delimited volume ranges"
+```
+
+---
+
+### Task 2: ParseVolumesFile
+
+**Files:**
+- Modify: `ranges/parser.go`
+- Modify: `ranges/parser_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `ranges/parser_test.go`. Add `"os"` to the import (change `import "testing"` to `import ("os" "testing")`):
+
+```go
+func TestParseVolumesFile(t *testing.T) {
+	// write a temp file with comments, blank lines, and decimal values
+	content := "# Volume 1\n1-8\n# Volume 2\n9-17\n\n18-25\n"
+	f, err := os.CreateTemp("", "volumes*.txt")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(f.Name())
+	if _, err := f.WriteString(content); err != nil {
+		t.Fatal(err)
+	}
+	f.Close()
+
+	vols, err := ParseVolumesFile(f.Name())
+	if err != nil {
+		t.Fatal(err)
+	}
+	// 3 non-blank non-comment lines → 3 volumes
+	if len(vols) != 3 {
+		t.Fatalf("expected 3 volumes, got %d", len(vols))
+	}
+	if vols[0][0].Begin != 1 || vols[0][0].End != 8 {
+		t.Error("expected volume 1 range 1-8")
+	}
+	if vols[1][0].Begin != 9 || vols[1][0].End != 17 {
+		t.Error("expected volume 2 range 9-17")
+	}
+	if vols[2][0].Begin != 18 || vols[2][0].End != 25 {
+		t.Error("expected volume 3 range 18-25")
+	}
+
+	// decimal chapter numbers
+	f2, err := os.CreateTemp("", "volumes*.txt")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(f2.Name())
+	f2.WriteString("168.1-170\n262.5\n")
+	f2.Close()
+
+	vols2, err := ParseVolumesFile(f2.Name())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if vols2[0][0].Begin != 168.1 || vols2[0][0].End != 170 {
+		t.Error("expected volume 1 range 168.1-170")
+	}
+	if vols2[1][0].Begin != 262.5 || vols2[1][0].End != 262.5 {
+		t.Error("expected volume 2 range 262.5-262.5")
+	}
+
+	// missing file returns error
+	_, err = ParseVolumesFile("/nonexistent/volumes.txt")
+	if err == nil {
+		t.Error("expected error for missing file")
+	}
+}
+```
+
+- [ ] **Step 2: Run the test to confirm it fails**
+
+```bash
+go test -v ./ranges/... -run TestParseVolumesFile
+```
+
+Expected: `FAIL` — `ParseVolumesFile` undefined.
+
+- [ ] **Step 3: Implement ParseVolumesFile**
+
+Add `"os"` to the imports in `ranges/parser.go` (the existing import is just `"strconv"` and `"strings"` — add `"os"`).
+
+Then append to `ranges/parser.go`:
+
+```go
+// ParseVolumesFile reads a plain-text file where each non-blank, non-comment
+// line is a chapter range (parsed by Parse). Lines starting with "#" are
+// treated as comments and skipped. Each line becomes one volume.
+func ParseVolumesFile(path string) ([][]Range, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	lines := strings.Split(string(data), "\n")
+	volumes := make([][]Range, 0, len(lines))
+	for _, line := range lines {
+		line = strings.TrimSpace(line)
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		rngs, err := Parse(line)
+		if err != nil {
+			return nil, err
+		}
+		volumes = append(volumes, rngs)
+	}
+	return volumes, nil
+}
+```
+
+- [ ] **Step 4: Run all range tests to confirm they pass**
+
+```bash
+go test -v ./ranges/...
+```
+
+Expected: all tests `PASS`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add ranges/parser.go ranges/parser_test.go
+git commit -m "feat(ranges): add ParseVolumesFile for file-based volume ranges"
+```
+
+---
+
+### Task 3: Volume filename support and PackVolume
+
+**Files:**
+- Modify: `packer/filename.go`
+- Create: `packer/filename_test.go`
+- Modify: `packer/pack.go`
+
+- [ ] **Step 1: Write the failing filename test**
+
+Create `packer/filename_test.go`:
+
+```go
+package packer
+
+import "testing"
+
+func TestVolumeFilenameTemplate(t *testing.T) {
+	parts := FilenameTemplateParts{
+		Series: "One Piece",
+		Volume: 1,
+	}
+	got, err := NewFilenameFromTemplate(FilenameVolumeTemplateDefault, parts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "One Piece Vol.01" {
+		t.Errorf("expected 'One Piece Vol.01', got '%s'", got)
+	}
+
+	// double-digit volume
+	parts.Volume = 12
+	got, err = NewFilenameFromTemplate(FilenameVolumeTemplateDefault, parts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "One Piece Vol.12" {
+		t.Errorf("expected 'One Piece Vol.12', got '%s'", got)
+	}
+
+	// version suffix when Version > 1 (duplicate filename handling)
+	parts.Volume = 1
+	parts.Version = 2
+	got, err = NewFilenameFromTemplate(FilenameVolumeTemplateDefault, parts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "One Piece Vol.01 v2" {
+		t.Errorf("expected 'One Piece Vol.01 v2', got '%s'", got)
+	}
+}
+```
+
+- [ ] **Step 2: Run the test to confirm it fails**
+
+```bash
+go test -v ./packer/... -run TestVolumeFilenameTemplate
+```
+
+Expected: `FAIL` — `FilenameVolumeTemplateDefault` undefined.
+
+- [ ] **Step 3: Add Volume field and default template to packer/filename.go**
+
+Add `Volume int` to `FilenameTemplateParts` and a new constant. The full updated file:
+
+```go
+package packer
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+	"text/template"
+
+	"github.com/elboletaire/manga-downloader/grabber"
+)
+
+// FilenameTemplateParts represents the parts of a filename
+type FilenameTemplateParts struct {
+	// Series represents the series name (e.g. "One Piece")
+	Series string
+	// Number represents the chapter number (e.g. "1.0")
+	Number string
+	// Title represents the chapter title (e.g. "The Beginning")
+	Title string
+	// Volume represents the volume number (e.g. 1)
+	Volume int
+	// Version placeholder appended to the title in case of duplicate filenames (e.g. "3")
+	Version int
+}
+
+// FilenameTemplateDefault is the default filename template for individual chapters
+const FilenameTemplateDefault = "{{.Series}} {{.Number}} - {{.Title}}{{if gt .Version 1}} v{{.Version}}{{end}}"
+
+// FilenameVolumeTemplateDefault is the default filename template for volume CBZ files
+const FilenameVolumeTemplateDefault = `{{.Series}} Vol.{{printf "%02d" .Volume}}{{if gt .Version 1}} v{{.Version}}{{end}}`
+
+// NewFilenameFromTemplate returns a new filename from a series title, a chapter and a template
+func NewFilenameFromTemplate(templ string, parts FilenameTemplateParts) (string, error) {
+	tmpl, err := template.New("filename").Parse(templ)
+	if err != nil {
+		return "", err
+	}
+
+	buffer := new(bytes.Buffer)
+	err = tmpl.Execute(buffer, parts)
+
+	return buffer.String(), err
+}
+
+// NewChapterFileTemplateParts returns a new FilenameTemplateParts from a title and a chapter
+func NewChapterFileTemplateParts(title string, chapter *grabber.Chapter) FilenameTemplateParts {
+	return FilenameTemplateParts{
+		Series: SanitizeFilename(title),
+		Number: strings.Replace(fmt.Sprintf("%.1f", chapter.GetNumber()), ".0", "", 1),
+		Title:  SanitizeFilename(chapter.GetTitle()),
+	}
+}
+
+// SanitizeFilename sanitizes a filename
+func SanitizeFilename(filename string) string {
+	sanitized := strings.Replace(filename, "/", "_", -1)
+	sanitized = strings.Replace(sanitized, "\\", "_", -1)
+	sanitized = strings.Replace(sanitized, ":", ";", -1)
+	sanitized = strings.Replace(sanitized, "?", "¿", -1)
+	sanitized = strings.Replace(sanitized, `"`, "'", -1)
+
+	return sanitized
+}
+```
+
+- [ ] **Step 4: Run the filename test to confirm it passes**
+
+```bash
+go test -v ./packer/... -run TestVolumeFilenameTemplate
+```
+
+Expected: `PASS`
+
+- [ ] **Step 5: Add PackVolume to packer/pack.go**
+
+Append to `packer/pack.go` (after the existing `PackBundle` function):
+
+```go
+// PackVolume packs a set of downloaded chapters into a single volume CBZ file.
+// volNum is the 1-based volume index used in the output filename.
+func PackVolume(outputdir, tmpl string, s grabber.Site, chapters []*DownloadedChapter, volNum int, progress func(page, progress int)) (string, error) {
+	title, _ := s.FetchTitle()
+	files := []*downloader.File{}
+	for _, chapter := range chapters {
+		files = append(files, chapter.Files...)
+	}
+	return pack(outputdir, tmpl, title, FilenameTemplateParts{
+		Series: SanitizeFilename(title),
+		Volume: volNum,
+	}, files, progress)
+}
+```
+
+- [ ] **Step 6: Build to confirm no compilation errors**
+
+```bash
+go build ./...
+```
+
+Expected: no output (success).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packer/filename.go packer/filename_test.go packer/pack.go
+git commit -m "feat(packer): add Volume field, FilenameVolumeTemplateDefault, and PackVolume"
+```
+
+---
+
+### Task 4: CLI flags and validation
+
+**Files:**
+- Modify: `cmd/root.go`
+
+- [ ] **Step 1: Add package-level vars and flags**
+
+In `cmd/root.go`, add three new package-level variables alongside the existing `var settings grabber.Settings`:
+
+```go
+var volumesStr string
+var volumeFile string
+var volumeFilenameTemplate string
+```
+
+In the `init()` function, append after the existing flag declarations:
+
+```go
+rootCmd.Flags().StringVar(&volumesStr, "volumes", "", `semicolon-delimited chapter ranges, one per volume (e.g. "1-8;9-17;18-25")`)
+rootCmd.Flags().StringVar(&volumeFile, "volume-file", "", "path to a file with one chapter range per line, each line becoming one volume")
+rootCmd.Flags().StringVar(&volumeFilenameTemplate, "volume-filename-template", packer.FilenameVolumeTemplateDefault, "template for volume output filenames")
+```
+
+- [ ] **Step 2: Add mutual-exclusion validation**
+
+In `Run`, directly after the `s.InitFlags(cmd)` call, add:
+
+```go
+if volumesStr != "" && volumeFile != "" {
+    cerr(fmt.Errorf("--volumes and --volume-file are mutually exclusive"), "")
+}
+if (volumesStr != "" || volumeFile != "") && settings.Bundle {
+    cerr(fmt.Errorf("--volumes/--volume-file and --bundle are mutually exclusive"), "")
+}
+if (volumesStr != "" || volumeFile != "") && len(args) > 1 {
+    cerr(fmt.Errorf("--volumes/--volume-file and a chapter range argument are mutually exclusive"), "")
+}
+```
+
+- [ ] **Step 3: Build to confirm no compilation errors**
+
+```bash
+go build ./...
+```
+
+Expected: no output (success).
+
+- [ ] **Step 4: Smoke-test flag registration**
+
+```bash
+go run . --help
+```
+
+Expected: `--volumes`, `--volume-file`, and `--volume-filename-template` appear in the flags list.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add cmd/root.go
+git commit -m "feat(cmd): add --volumes, --volume-file, --volume-filename-template flags"
+```
+
+---
+
+### Task 5: Volume download loop
+
+**Files:**
+- Modify: `cmd/root.go`
+
+- [ ] **Step 1: Add the volume download loop to Run**
+
+In `Run`, after the `chapters = chapters.SortByNumber()` line and before the existing range-parsing block (the `var rngs []ranges.Range` line), insert the volume handling block:
+
+```go
+// volume mode: download and pack chapters into per-volume CBZ files
+if volumesStr != "" || volumeFile != "" {
+    var volumeRanges [][]ranges.Range
+    if volumesStr != "" {
+        volumeRanges, err = ranges.ParseVolumes(volumesStr)
+    } else {
+        volumeRanges, err = ranges.ParseVolumesFile(volumeFile)
+    }
+    cerr(err, "Error parsing volumes: ")
+
+    for i, volRanges := range volumeRanges {
+        volNum := i + 1
+
+        volChapters := chapters.FilterRanges(volRanges)
+        if len(volChapters) == 0 {
+            color.Yellow("Vol.%02d: no chapters found in specified range, skipping", volNum)
+            continue
+        }
+
+        // pre-fetch page counts for progress bar total
+        totalPages := int64(0)
+        for _, chap := range volChapters {
+            chapter, err := s.FetchChapter(chap)
+            if err == nil && chapter != nil {
+                totalPages += chapter.PagesCount
+            }
+        }
+
+        // progress bar for this volume
+        p := mpb.New(
+            mpb.WithWidth(40),
+            mpb.WithOutput(color.Output),
+            mpb.WithAutoRefresh(),
+        )
+        volLabel := fmt.Sprintf("Vol.%02d", volNum)
+        bar := p.AddBar(totalPages*2,
+            mpb.PrependDecorators(
+                decor.Any(func(s decor.Statistics) string {
+                    return blue.Sprintf("%-30s", volLabel)
+                }, decor.WCSyncWidthR),
+                decor.CountersNoUnit("%d/%d", decor.WC{C: decor.DextraSpace}),
+            ),
+            mpb.AppendDecorators(
+                decor.Percentage(decor.WC{W: 4}),
+                decor.Any(func(s decor.Statistics) string {
+                    if s.Current >= s.Total {
+                        return blue.Sprintf(" bundling ")
+                    }
+                    return blue.Sprintf(" downloading")
+                }, decor.WC{W: 10}),
+            ),
+        )
+
+        // download chapters concurrently
+        wg := sync.WaitGroup{}
+        g := make(chan struct{}, s.GetMaxConcurrency().Chapters)
+        downloaded := grabber.Filterables{}
+
+        for _, chap := range volChapters {
+            g <- struct{}{}
+            wg.Add(1)
+            go func(chap grabber.Filterable) {
+                defer wg.Done()
+                chapter, err := s.FetchChapter(chap)
+                if err != nil {
+                    color.Red("- error fetching chapter %s: %s", chap.GetTitle(), err.Error())
+                    <-g
+                    return
+                }
+                files, err := downloader.FetchChapter(s, chapter, func(_ int, idx int, err error) {
+                    if err != nil {
+                        color.Red("- error downloading page %d: %s", idx+1, err.Error())
+                    } else {
+                        bar.IncrBy(1)
+                    }
+                })
+                if err != nil {
+                    color.Red("- error downloading chapter %s: %s", chapter.GetTitle(), err.Error())
+                    <-g
+                    return
+                }
+                bar.IncrBy(int(chapter.PagesCount))
+                downloaded = append(downloaded, &packer.DownloadedChapter{
+                    Chapter: chapter,
+                    Files:   files,
+                })
+                <-g
+            }(chap)
+        }
+        wg.Wait()
+        close(g)
+        p.Wait()
+
+        // sort and convert for packing
+        downloaded = downloaded.SortByNumber()
+        dc := make([]*packer.DownloadedChapter, 0, len(downloaded))
+        for _, d := range downloaded {
+            dc = append(dc, d.(*packer.DownloadedChapter))
+        }
+
+        filename, err := packer.PackVolume(settings.OutputDir, volumeFilenameTemplate, s, dc, volNum, func(_, _ int) {})
+        if err != nil {
+            color.Red(err.Error())
+            continue
+        }
+        fmt.Printf("- %s %s\n", color.GreenString("saved file"), color.HiBlackString(filename))
+    }
+    os.Exit(0)
+}
+```
+
+Note: `err` is already declared earlier in `Run` (from `title, err := s.FetchTitle()`), so use `=` not `:=` when assigning `volumeRanges, err`.
+
+- [ ] **Step 2: Build to confirm no compilation errors**
+
+```bash
+go build ./...
+```
+
+Expected: no output (success).
+
+- [ ] **Step 3: Run all tests**
+
+```bash
+go test -v ./...
+```
+
+Expected: all tests `PASS`.
+
+- [ ] **Step 4: Smoke-test with a real URL (optional but recommended)**
+
+```bash
+go run . --volumes "1-3;4-6" https://mangabuddy.com/jujutsu-kaisen
+```
+
+Expected: two files created — `Jujutsu Kaisen Vol.01.cbz` (chapters 1–3) and `Jujutsu Kaisen Vol.02.cbz` (chapters 4–6).
+
+Test `--volume-file`:
+```
+# volumes.txt
+1-3
+4-6
+```
+```bash
+go run . --volume-file volumes.txt https://mangabuddy.com/jujutsu-kaisen
+```
+
+Expected: same two files as above.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add cmd/root.go
+git commit -m "feat(cmd): add volume download loop for --volumes and --volume-file"
+```
+
+- [ ] **Step 6: Push**
+
+```bash
+git push origin master
+```

--- a/docs/superpowers/specs/2026-04-04-volume-batching-design.md
+++ b/docs/superpowers/specs/2026-04-04-volume-batching-design.md
@@ -1,0 +1,84 @@
+# Volume Batching Design
+
+## Overview
+
+Add support for batching downloaded chapters into per-volume CBZ files. Volume boundaries are always user-specified — either via a CLI flag or a file. When no volumes are specified, all existing behavior is unchanged.
+
+## CLI
+
+Two new flags:
+
+- `--volumes "1-8;9-17;18-25"` — semicolon-delimited list of chapter ranges, one per volume. Commas within a segment work as they do today (e.g. `1-8,10` is valid).
+- `--volume-file path/to/file.txt` — path to a plain text file with one range per line.
+
+One new optional flag:
+
+- `--volume-filename-template` — Go template string for volume output filenames. Defaults to `{{.Series}} Vol.{{printf "%02d" .Volume}}`.
+
+Constraints (any violation is a fatal error with a clear message):
+
+- `--volumes` and `--volume-file` are mutually exclusive.
+- `--volumes`/`--volume-file` and `--bundle` are mutually exclusive.
+- `--volumes`/`--volume-file` and a positional chapter range argument are mutually exclusive.
+
+## Range Parsing
+
+Two new functions added to the `ranges` package:
+
+```go
+// ParseVolumes splits on ";" and calls Parse() on each segment.
+// Returns a slice of range-slices; each inner slice is one volume.
+func ParseVolumes(s string) ([][]Range, error)
+
+// ParseVolumesFile reads a file line by line, skipping blank lines
+// and lines starting with "#", and calls Parse() on each line.
+func ParseVolumesFile(path string) ([][]Range, error)
+```
+
+Both delegate to the existing `Parse()` which uses `float64` internally, so decimal chapter numbers (e.g. `168.1`, `262.5`) are supported with no extra work.
+
+Example volume file format:
+
+```
+# Volume 1
+1-8
+# Volume 2
+9-17,19
+# Volume 3
+20-25.5
+```
+
+Volume numbers are positional — the first entry is Vol.1, the second is Vol.2, etc.
+
+## Output Filenames
+
+Add `Volume int` to `FilenameTemplateParts` in `packer/filename.go`.
+
+New default volume template constant:
+
+```go
+const FilenameVolumeTemplateDefault = `{{.Series}} Vol.{{printf "%02d" .Volume}}`
+```
+
+Produces e.g. `One Piece Vol.01.cbz`, `One Piece Vol.02.cbz`. Zero-padding to 2 digits handles up to 99 volumes and ensures correct lexicographic sort order in file browsers.
+
+## Download Flow
+
+When volumes are active, `cmd/root.go`:
+
+1. Fetches and sorts all chapters from the site (same as today).
+2. Iterates over volumes **sequentially**, one at a time.
+3. For each volume:
+   - Filters the full chapter list to the volume's ranges.
+   - Downloads all chapters in the volume concurrently (same goroutine/semaphore logic as today).
+   - Packs into a single CBZ via the existing `PackBundle`, passing the volume number for the filename.
+4. Progress bar labels include the current volume (e.g. `Vol.01 - Chapter 5:`).
+
+Volumes are processed sequentially rather than in parallel to avoid hammering the server. Per-chapter concurrency within each volume is unchanged.
+
+## Files Changed
+
+- `ranges/parser.go` — add `ParseVolumes` and `ParseVolumesFile`
+- `ranges/parser_test.go` — add tests for both new functions, including decimal values
+- `packer/filename.go` — add `Volume int` to `FilenameTemplateParts`, add `FilenameVolumeTemplateDefault`
+- `cmd/root.go` — add `--volumes`, `--volume-file`, `--volume-filename-template` flags; add volume download loop

--- a/grabber/mangabuddy.go
+++ b/grabber/mangabuddy.go
@@ -1,0 +1,152 @@
+package grabber
+
+import (
+	"regexp"
+	"strconv"
+	"strings"
+
+	"github.com/PuerkitoBio/goquery"
+	"github.com/elboletaire/manga-downloader/http"
+)
+
+// MangaBuddy is a grabber for mangabuddy.com
+type MangaBuddy struct {
+	*Grabber
+	title string
+}
+
+func NewMangaBuddy(g *Grabber) *MangaBuddy {
+	return &MangaBuddy{Grabber: g}
+}
+
+// MangaBuddyChapter represents a MangaBuddy chapter
+type MangaBuddyChapter struct {
+	Chapter
+	URL string
+}
+
+// Test checks if the URL is a MangaBuddy URL
+func (m *MangaBuddy) Test() (bool, error) {
+	re := regexp.MustCompile(`mangabuddy\.com`)
+	return re.MatchString(m.URL), nil
+}
+
+// FetchTitle fetches the manga title from the main page
+func (m *MangaBuddy) FetchTitle() (string, error) {
+	if m.title != "" {
+		return m.title, nil
+	}
+
+	body, err := http.Get(http.RequestParams{URL: m.URL})
+	if err != nil {
+		return "", err
+	}
+	defer body.Close()
+
+	doc, err := goquery.NewDocumentFromReader(body)
+	if err != nil {
+		return "", err
+	}
+
+	m.title = sanitizeTitle(doc.Find("h1").Text())
+
+	return m.title, nil
+}
+
+// FetchChapters fetches all chapters from the MangaBuddy chapters API
+func (m *MangaBuddy) FetchChapters() (Filterables, []error) {
+	slug := m.slug()
+
+	body, err := http.Get(http.RequestParams{
+		URL: m.BaseUrl() + "/api/manga/" + slug + "/chapters?source=detail",
+	})
+	if err != nil {
+		return nil, []error{err}
+	}
+	defer body.Close()
+
+	doc, err := goquery.NewDocumentFromReader(body)
+	if err != nil {
+		return nil, []error{err}
+	}
+
+	re := regexp.MustCompile(`C(?:hapter|\.)?\s*(\d+\.?\d*)`)
+
+	var chapters Filterables
+	var errs []error
+
+	doc.Find("li a").Each(func(_ int, s *goquery.Selection) {
+		title := s.Find("strong").Text()
+		match := re.FindStringSubmatch(title)
+		if len(match) == 0 {
+			return
+		}
+
+		number, err := strconv.ParseFloat(match[1], 64)
+		if err != nil {
+			errs = append(errs, err)
+			return
+		}
+
+		href := s.AttrOr("href", "")
+		if !strings.HasPrefix(href, "http") {
+			href = m.BaseUrl() + href
+		}
+
+		chapters = append(chapters, &MangaBuddyChapter{
+			Chapter: Chapter{
+				Number: number,
+				Title:  title,
+			},
+			URL: href,
+		})
+	})
+
+	return chapters, errs
+}
+
+// FetchChapter fetches a chapter's pages
+func (m *MangaBuddy) FetchChapter(f Filterable) (*Chapter, error) {
+	mchap := f.(*MangaBuddyChapter)
+
+	body, err := http.Get(http.RequestParams{URL: mchap.URL})
+	if err != nil {
+		return nil, err
+	}
+	defer body.Close()
+
+	doc, err := goquery.NewDocumentFromReader(body)
+	if err != nil {
+		return nil, err
+	}
+
+	pimages := getPlainHTMLImageURL(".chapter-image img", doc)
+
+	chapter := &Chapter{
+		Title:      f.GetTitle(),
+		Number:     f.GetNumber(),
+		PagesCount: int64(len(pimages)),
+		Language:   "en",
+	}
+
+	for i, img := range pimages {
+		if img == "" {
+			continue
+		}
+		if !strings.HasPrefix(img, "http") {
+			img = m.BaseUrl() + img
+		}
+		chapter.Pages = append(chapter.Pages, Page{
+			Number: int64(i),
+			URL:    img,
+		})
+	}
+
+	return chapter, nil
+}
+
+// slug extracts the manga slug from the URL path
+func (m *MangaBuddy) slug() string {
+	parts := strings.Split(strings.TrimRight(m.URL, "/"), "/")
+	return parts[len(parts)-1]
+}

--- a/grabber/plainhtml.go
+++ b/grabber/plainhtml.go
@@ -52,14 +52,6 @@ func (m *PlainHTML) Test() (bool, error) {
 
 	// order is important, since some sites have very similar selectors
 	selectors := []SiteSelector{
-		{
-			Title:        "h1",
-			Rows:         "#chapter-list > li",
-			Chapter:      ".chapter-title",
-			ChapterTitle: ".chapter-title",
-			Link:         "a",
-			Image:        ".chapter-image img",
-		},
 		// tcbscans.com
 		{
 			Title:        "h1",

--- a/grabber/site.go
+++ b/grabber/site.go
@@ -68,6 +68,7 @@ type Site interface {
 // IdentifySite returns the site passing the Test() for the specified url
 func (g *Grabber) IdentifySite() (Site, []error) {
 	sites := []Site{
+		NewMangaBuddy(g),
 		NewPlainHTML(g),
 		NewInmanga(g),
 		NewMangadex(g),

--- a/packer/filename.go
+++ b/packer/filename.go
@@ -17,12 +17,17 @@ type FilenameTemplateParts struct {
 	Number string
 	// Title represents the chapter title (e.g. "The Beginning")
 	Title string
+	// Volume represents the volume number (e.g. 1)
+	Volume int
 	// Version placeholder appended to the title in case of duplicate filenames (e.g. "3")
 	Version int
 }
 
-// FilenameTemplateDefault is the default filename template
+// FilenameTemplateDefault is the default filename template for individual chapters
 const FilenameTemplateDefault = "{{.Series}} {{.Number}} - {{.Title}}{{if gt .Version 1}} v{{.Version}}{{end}}"
+
+// FilenameVolumeTemplateDefault is the default filename template for volume CBZ files
+const FilenameVolumeTemplateDefault = `{{.Series}} Vol.{{printf "%02d" .Volume}}{{if gt .Version 1}} v{{.Version}}{{end}}`
 
 // NewFilenameFromTemplate returns a new filename from a series title, a chapter and a template
 func NewFilenameFromTemplate(templ string, parts FilenameTemplateParts) (string, error) {

--- a/packer/filename_test.go
+++ b/packer/filename_test.go
@@ -1,0 +1,38 @@
+package packer
+
+import "testing"
+
+func TestVolumeFilenameTemplate(t *testing.T) {
+	parts := FilenameTemplateParts{
+		Series: "One Piece",
+		Volume: 1,
+	}
+	got, err := NewFilenameFromTemplate(FilenameVolumeTemplateDefault, parts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "One Piece Vol.01" {
+		t.Errorf("expected 'One Piece Vol.01', got '%s'", got)
+	}
+
+	// double-digit volume
+	parts.Volume = 12
+	got, err = NewFilenameFromTemplate(FilenameVolumeTemplateDefault, parts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "One Piece Vol.12" {
+		t.Errorf("expected 'One Piece Vol.12', got '%s'", got)
+	}
+
+	// version suffix when Version > 1 (duplicate filename handling)
+	parts.Volume = 1
+	parts.Version = 2
+	got, err = NewFilenameFromTemplate(FilenameVolumeTemplateDefault, parts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "One Piece Vol.01 v2" {
+		t.Errorf("expected 'One Piece Vol.01 v2', got '%s'", got)
+	}
+}

--- a/packer/pack.go
+++ b/packer/pack.go
@@ -36,6 +36,20 @@ func PackBundle(outputdir string, s grabber.Site, chapters []*DownloadedChapter,
 	}, files, progress)
 }
 
+// PackVolume packs a set of downloaded chapters into a single volume CBZ file.
+// volNum is the 1-based volume index used in the output filename.
+func PackVolume(outputdir, tmpl string, s grabber.Site, chapters []*DownloadedChapter, volNum int, progress func(page, progress int)) (string, error) {
+	title, _ := s.FetchTitle()
+	files := []*downloader.File{}
+	for _, chapter := range chapters {
+		files = append(files, chapter.Files...)
+	}
+	return pack(outputdir, tmpl, title, FilenameTemplateParts{
+		Series: SanitizeFilename(title),
+		Volume: volNum,
+	}, files, progress)
+}
+
 func pack(outputdir, template, title string, parts FilenameTemplateParts, files []*downloader.File, progress func(page, progress int)) (string, error) {
 	parts.Version = 1
 

--- a/ranges/parser.go
+++ b/ranges/parser.go
@@ -1,6 +1,7 @@
 package ranges
 
 import (
+	"os"
 	"strconv"
 	"strings"
 )
@@ -64,6 +65,30 @@ func ParseVolumes(s string) ([][]Range, error) {
 			continue
 		}
 		rngs, err := Parse(seg)
+		if err != nil {
+			return nil, err
+		}
+		volumes = append(volumes, rngs)
+	}
+	return volumes, nil
+}
+
+// ParseVolumesFile reads a plain-text file where each non-blank, non-comment
+// line is a chapter range (parsed by Parse). Lines starting with "#" are
+// treated as comments and skipped. Each line becomes one volume.
+func ParseVolumesFile(path string) ([][]Range, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	lines := strings.Split(string(data), "\n")
+	volumes := make([][]Range, 0, len(lines))
+	for _, line := range lines {
+		line = strings.TrimSpace(line)
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		rngs, err := Parse(line)
 		if err != nil {
 			return nil, err
 		}

--- a/ranges/parser.go
+++ b/ranges/parser.go
@@ -51,3 +51,23 @@ func Parse(rnge string) (rngs []Range, err error) {
 
 	return
 }
+
+// ParseVolumes parses a semicolon-delimited string of chapter ranges into
+// a slice of range-slices, where each inner slice represents one volume.
+// Commas within a segment work the same as in Parse (e.g. "1-8,10" is valid).
+func ParseVolumes(s string) ([][]Range, error) {
+	segments := strings.Split(s, ";")
+	volumes := make([][]Range, 0, len(segments))
+	for _, seg := range segments {
+		seg = strings.TrimSpace(seg)
+		if seg == "" {
+			continue
+		}
+		rngs, err := Parse(seg)
+		if err != nil {
+			return nil, err
+		}
+		volumes = append(volumes, rngs)
+	}
+	return volumes, nil
+}

--- a/ranges/parser_test.go
+++ b/ranges/parser_test.go
@@ -20,3 +20,53 @@ func TestRangesParsing(t *testing.T) {
 		t.Error("Expected range 55-1059")
 	}
 }
+
+func TestParseVolumes(t *testing.T) {
+	// basic three-volume split
+	vols, err := ParseVolumes("1-8;9-17;18-25")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(vols) != 3 {
+		t.Fatalf("expected 3 volumes, got %d", len(vols))
+	}
+	if vols[0][0].Begin != 1 || vols[0][0].End != 8 {
+		t.Error("expected volume 1 range 1-8")
+	}
+	if vols[1][0].Begin != 9 || vols[1][0].End != 17 {
+		t.Error("expected volume 2 range 9-17")
+	}
+	if vols[2][0].Begin != 18 || vols[2][0].End != 25 {
+		t.Error("expected volume 3 range 18-25")
+	}
+
+	// decimal chapter numbers
+	vols2, err := ParseVolumes("168.1-170;262.5")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if vols2[0][0].Begin != 168.1 || vols2[0][0].End != 170 {
+		t.Error("expected volume 1 range 168.1-170")
+	}
+	if vols2[1][0].Begin != 262.5 || vols2[1][0].End != 262.5 {
+		t.Error("expected volume 2 range 262.5-262.5")
+	}
+
+	// comma-separated chapters within a volume
+	vols3, err := ParseVolumes("1-8,10;9-17")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(vols3[0]) != 2 {
+		t.Errorf("expected volume 1 to have 2 ranges, got %d", len(vols3[0]))
+	}
+	if vols3[0][1].Begin != 10 || vols3[0][1].End != 10 {
+		t.Error("expected second range of volume 1 to be 10-10")
+	}
+
+	// invalid range returns error
+	_, err = ParseVolumes("abc")
+	if err == nil {
+		t.Error("expected error for invalid range")
+	}
+}

--- a/ranges/parser_test.go
+++ b/ranges/parser_test.go
@@ -1,6 +1,9 @@
 package ranges
 
-import "testing"
+import (
+	"os"
+	"testing"
+)
 
 func TestRangesParsing(t *testing.T) {
 	rngs, err := Parse("1-20,23,55-1059")
@@ -68,5 +71,63 @@ func TestParseVolumes(t *testing.T) {
 	_, err = ParseVolumes("abc")
 	if err == nil {
 		t.Error("expected error for invalid range")
+	}
+}
+
+func TestParseVolumesFile(t *testing.T) {
+	// write a temp file with comments, blank lines, and decimal values
+	content := "# Volume 1\n1-8\n# Volume 2\n9-17\n\n18-25\n"
+	f, err := os.CreateTemp("", "volumes*.txt")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(f.Name())
+	if _, err := f.WriteString(content); err != nil {
+		t.Fatal(err)
+	}
+	f.Close()
+
+	vols, err := ParseVolumesFile(f.Name())
+	if err != nil {
+		t.Fatal(err)
+	}
+	// 3 non-blank non-comment lines → 3 volumes
+	if len(vols) != 3 {
+		t.Fatalf("expected 3 volumes, got %d", len(vols))
+	}
+	if vols[0][0].Begin != 1 || vols[0][0].End != 8 {
+		t.Error("expected volume 1 range 1-8")
+	}
+	if vols[1][0].Begin != 9 || vols[1][0].End != 17 {
+		t.Error("expected volume 2 range 9-17")
+	}
+	if vols[2][0].Begin != 18 || vols[2][0].End != 25 {
+		t.Error("expected volume 3 range 18-25")
+	}
+
+	// decimal chapter numbers
+	f2, err := os.CreateTemp("", "volumes*.txt")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(f2.Name())
+	f2.WriteString("168.1-170\n262.5\n")
+	f2.Close()
+
+	vols2, err := ParseVolumesFile(f2.Name())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if vols2[0][0].Begin != 168.1 || vols2[0][0].End != 170 {
+		t.Error("expected volume 1 range 168.1-170")
+	}
+	if vols2[1][0].Begin != 262.5 || vols2[1][0].End != 262.5 {
+		t.Error("expected volume 2 range 262.5-262.5")
+	}
+
+	// missing file returns error
+	_, err = ParseVolumesFile("/nonexistent/volumes.txt")
+	if err == nil {
+		t.Error("expected error for missing file")
 	}
 }


### PR DESCRIPTION
The original PlainHTML-based approach only scraped the initial page HTML, which contains a partial chapter list. This caused chapters in the middle to be skipped (e.g. chapters 10-190 missing for Jujutsu Kaisen).

Replace with a dedicated MangaBuddy grabber that fetches the complete chapter list from /api/manga/{slug}/chapters?source=detail.