### PR TITLE
feat: browser rendering layer + six new sites (v1.0.0)

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -19,17 +19,17 @@ jobs:
           - goarch: arm64
             goos: windows
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Get short version and tag
       run: |
         echo "sha_short=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
         echo "tag=$(git describe --tags)" >> $GITHUB_ENV
-    - uses: wangyoucao577/go-release-action@v1.34
+    - uses: wangyoucao577/go-release-action@v1.55
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         goos: ${{ matrix.goos }}
         goarch: ${{ matrix.goarch }}
-        goversion: "1.19"
+        goversion: "1.26"
         project_path: "."
         binary_name: "manga-downloader"
         extra_files: LICENSE README.md

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -6,12 +6,12 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Set up Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v5
         with:
-          go-version: 1.19
+          go-version: "1.26"
 
       - name: Test
         run: make test

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 manga-downloader
 *.cbz
 demos/*.yml
+.worktrees

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,64 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project
+
+Go CLI (cobra) that downloads manga chapters from supported websites and packs them into CBZ files. Module: `github.com/elboletaire/manga-downloader`, Go 1.19.
+
+## Commands
+
+```bash
+make install          # go mod download
+make build            # clean + test + build unix binary (injects version via ldflags)
+make build/all        # unix + windows binaries
+make test             # go test -v ./... (uses richgo if installed)
+go test ./ranges -run TestParse   # run a single test
+make clean            # remove built binaries and *.cbz files
+```
+
+Unit test coverage is minimal (only `ranges/parser_test.go`). Real-world verification is done with the makefile smoke targets, which run the app against live sites:
+
+```bash
+make grabber          # all of the below
+make grabber/inmanga
+make grabber/mangadex
+make grabber/mangabats
+make grabber/tcb
+make grabber/html     # runs a list of plainhtml-based sites
+```
+
+These hit live websites and download actual chapters, so run them selectively.
+
+## Architecture
+
+The download flow, all orchestrated from `cmd/root.go` (`Run`):
+
+1. `grabber.NewSite(url, settings)` → `IdentifySite()` iterates the registered grabbers (`grabber/site.go`) and calls `Test()` on each, which fetches the URL and checks if the site matches. **Order matters**: `PlainHTML` is tried first, then site-specific grabbers (Inmanga, Mangadex, Tcb).
+2. The matched `Site` fetches title and chapters (`FetchChapters` returns `Filterables`), the user's range argument (`ranges.Parse`, format `1-10,12,15-20`) filters them.
+3. Chapters download concurrently (`downloader.FetchChapter`), bounded by `--concurrency` (chapters, max 5) and `--concurrency-pages` (max 10) semaphores. Pages are fetched via the `http` package (plain GETs with a Referer header).
+4. `packer` writes CBZ files (`PackSingle` per chapter or `PackBundle` with `--bundle`), naming them via a Go text/template (`--filename-template`, parts in `packer/filename.go`). Duplicate filenames get a `v{{.Version}}` suffix instead of being overwritten.
+
+### The grabber package
+
+- `Site` interface (`grabber/site.go`) is the contract for all grabbers: `Test`, `FetchTitle`, `FetchChapters`, `FetchChapter`, etc. The base `Grabber` struct provides shared settings/helpers.
+- `Filterable`/`Filterables` (`grabber/filterable.go`) abstracts chapters so they can be sorted/filtered by number; each grabber has its own chapter struct embedding `grabber.Chapter`.
+- `PlainHTML` (`grabber/plainhtml.go`) is a generic goquery scraper driven by a list of `SiteSelector` entries (CSS selectors for title/rows/chapter/image). It covers mangabuddy, tcbonepiecechapters.com (TCB Scans) and asurascans.com. Selector order in the list matters because some sites have very similar markup.
+- Site-specific grabbers with their own logic: `inmanga.go`, `mangadex.go` (both API-based, language-aware), `mangabats.go` (JSON chapters API + js image variables), `qimanga.go` (paginated JSON chapters API + SSR reader), `tcb.go` (Madara-based wordpress sites, i.e. lhtranslation.net).
+
+### Adding support for a new site
+
+- If the site is plain HTML (chapter list + images in the reader page): add a `SiteSelector` entry to the list in `PlainHTML.Test()`, and add a smoke-test URL to the `grabber/html` makefile target and the README's supported sites list.
+- Otherwise: create a new grabber implementing `Site` (embed `*Grabber`), and register it in `IdentifySite()`.
+
+### Investigating/testing sites
+
+Lessons from past site-support work (July 2026):
+
+- **Triage with curl before touching Go.** Fetch the manga page with a browser User-Agent and check the `<title>`: "Just a moment..." means a Cloudflare JS challenge and the site cannot be supported with plain HTTP (same for TLS-level connection drops, empty-`<div id="app-root">` SPAs, or encrypted-image readers like colamanga). Don't burn time debugging the grabber in those cases.
+- **Verify CBZ contents, not just their existence.** A run can "succeed" while producing empty or junk archives. Check that entries have non-zero sizes and real image magic bytes (JPG/PNG/WebP/GIF).
+- **403/500 in the app but 200 in curl almost always means headers.** `http/request.go` sends a browser User-Agent, Accept, Accept-Language, and referers with a trailing slash — all four exist because some site rejected requests without them. Compare headers before assuming a site is down.
+- **Smoke-test with recent chapters.** Some sites drop old content from their CDNs (inmanga 404s on early One Piece chapters) and MangaDex replaces licensed chapters with pageless external stubs, so "chapter 1" is often the worst test target.
+- **Sites move domains constantly.** Before declaring a site dead, probe for successors (e.g. tcbscans.com → tcbonepiecechapters.com, mangabat → mangabats.com, asuratoon → asurascans.com); redirects may only preserve the homepage, not series paths.
+- The makefile is tracked as lowercase `makefile`: on macOS's case-insensitive filesystem editing `Makefile` works, but `git add` needs the lowercase name.
+- macOS has no `timeout` command; use the Bash tool's timeout or a background-kill wrapper when running live-site smoke tests.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,7 +44,18 @@ The download flow, all orchestrated from `cmd/root.go` (`Run`):
 - `Site` interface (`grabber/site.go`) is the contract for all grabbers: `Test`, `FetchTitle`, `FetchChapters`, `FetchChapter`, etc. The base `Grabber` struct provides shared settings/helpers.
 - `Filterable`/`Filterables` (`grabber/filterable.go`) abstracts chapters so they can be sorted/filtered by number; each grabber has its own chapter struct embedding `grabber.Chapter`.
 - `PlainHTML` (`grabber/plainhtml.go`) is a generic goquery scraper driven by a list of `SiteSelector` entries (CSS selectors for title/rows/chapter/image). It covers mangabuddy, tcbonepiecechapters.com (TCB Scans) and asurascans.com. Selector order in the list matters because some sites have very similar markup.
-- Site-specific grabbers with their own logic: `inmanga.go`, `mangadex.go` (both API-based, language-aware), `mangabats.go` (JSON chapters API + js image variables), `qimanga.go` (paginated JSON chapters API + SSR reader), `tcb.go` (Madara-based wordpress sites, i.e. lhtranslation.net).
+- Site-specific grabbers with their own logic: `inmanga.go`, `mangadex.go` (both API-based, language-aware), `mangabats.go` (JSON chapters API + js image variables), `mangafire.go` (open JSON API: `/api/titles/{hid}` + paginated `/chapters` + `/api/chapters/{id}` for pages, language-aware), `qimanga.go` (paginated JSON chapters API + SSR reader), `tcb.go` (Madara-based wordpress sites, i.e. lhtranslation.net).
+
+### The browser package
+
+`browser/browser.go` drives a locally-installed Chromium browser (Chrome/Chromium/Brave/Edge, auto-discovered by chromedp's `ExecAllocator`) for sites plain HTTP can't scrape: JS-rendered pages, TLS-fingerprint blocks, or Cloudflare challenges. One shared browser process is started lazily and reused. `GetHTML(url, waitSelector, timeout)` returns rendered HTML and harvests the session cookies + real UA into the `http` package (`http/session.go`), so images still download via the fast plain-HTTP path reusing the browser's Cloudflare clearance.
+
+`grabber/plainhtmlbrowser.go` (`PlainHTMLBrowser`) is the browser-rendered twin of `PlainHTML`: it reuses all the selector-driven parsing (`chapterFromDoc`), but matches sites **by domain** (a `browserSelectors` list of `BrowserSiteSelector`, no fetch — starting a browser is expensive) and fetches series/reader pages through Chrome. Registered first in `IdentifySite()`. Covers toongod, dragontea, kappabeast, sushiscan.
+
+- **Headless loses to Cloudflare; headed usually wins.** CDP automation is detectable, so CF challenges time out in headless mode. The `--browser-visible` flag (`browser.SetVisible`) runs headed, where managed challenges resolve in a couple of seconds and the user can solve an interactive one manually. The wait-selector timeout error hints at `--browser-visible` when headless.
+- **Always try the site's own API/HTTP first.** mangafire looks like it needs a browser (SPA behind CF), but its JSON API is wide open to plain HTTP — no browser needed. zonatmo's successor domain dropped the TLS block, so it's plain `PlainHTML` now. Only reach for `PlainHTMLBrowser` when HTTP genuinely can't get the data.
+- **`tools/probe`** is the investigation tool: renders a URL in Chrome and tests selectors. Env knobs: `PROBE_VISIBLE=1` (headed), `PROBE_SLEEP=8s` (settle time for lazy SPAs), `PROBE_DUMP=/tmp/x.html` (dump HTML), `PROBE_NETLOG=1` (log non-asset network responses — how the mangafire `/api/chapters/{id}` endpoint was found), `PROBE_FETCH_SEL="sel"` (grab first matching image and test a plain-HTTP download with the harvested session).
+- **Sites keep moving/locking down.** zonatmo.com → taken down (Spanish police, Apr 2026) → successor zonatmo.org. colamanga → redirects to yoyomanga.com and now gates the reader behind their app (`APP观看该内容`) on top of client-side image encryption — not feasible, left unsupported (#30).
 
 ### Adding support for a new site
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Supported sites
 - [mangabats.com (former mangabat.com)](https://www.mangabats.com)
 - [mangabuddy.com](https://mangabuddy.com) (currently down, kept in case it comes back)
 - [Mangadex](https://mangadex.org)
+- [qimanga.com](https://qimanga.com)
 - [tcbonepiecechapters.com (TCB Scans, former tcbscans.com)](https://tcbonepiecechapters.com)
 
 It may support even more sites of which I'm not aware. If you find a site that is not supported, feel free to open a new issue or a PR with the implementation.

--- a/README.md
+++ b/README.md
@@ -16,24 +16,13 @@ files, so you can read them with your favorite ereader or reading app.
 Supported sites
 ---------------
 
-- [asuratoon.com (Asura Scans)](https://asuratoon.com)
-- [chapmanganato.to](https://chapmanganato.to)
+- [asurascans.com (Asura Scans, former asuratoon.com)](https://asurascans.com)
 - [inmanga.com](https://inmanga.com)
 - [LHTranslation](https://lhtranslation.net)
-- [lscomic.com](https://lscomic.com/)
-- [Manga Monks](https://mangamonks.com)
-- [mangabat.com](https://mangabat.com)
+- [mangabats.com (former mangabat.com)](https://www.mangabats.com)
+- [mangabuddy.com](https://mangabuddy.com) (currently down, kept in case it comes back)
 - [Mangadex](https://mangadex.org)
-- [mangakakalot.com](https://mangakakalot.com)
-- [mangakakalot.tv](https://mangakakalot.tv)
-- [manganato.com](https://manganato.com)
-- [manganelo.com](https://manganelo.com)
-- [manganelo.tv](https://manganelo.tv)
-- [mangapanda.in](https://mangapanda.in)
-- [readmangabat.com](https://readmangabat.com)
-- [tcbscans.com](https://tcbscans.com)
-- [tcbscans.net](https://www.tcbscans.net)
-- [tcbscans.org](https://www.tcbscans.org)
+- [tcbonepiecechapters.com (TCB Scans, former tcbscans.com)](https://tcbonepiecechapters.com)
 
 It may support even more sites of which I'm not aware. If you find a site that is not supported, feel free to open a new issue or a PR with the implementation.
 

--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ Manga Downloader [![starline]](#star-history-)
 [![Docker Pulls][pulls badge]][docker hub]
 [![License][license badge]][license]
 
-This app downloads manga from websites like mangadex and stores them into cbz
-files, so you can read them with your favorite ereader or reading app.
+Download manga chapters from websites like MangaDex and pack them into CBZ
+files, ready to read on your favorite ereader or reading app.
 
 ![prompt img]
 
@@ -17,140 +17,181 @@ Supported sites
 ---------------
 
 - [asurascans.com (Asura Scans, former asuratoon.com)](https://asurascans.com)
+- [dragontea.ink](https://dragontea.ink) \*
 - [inmanga.com](https://inmanga.com)
+- [kappabeast.com](https://kappabeast.com) \*
 - [LHTranslation](https://lhtranslation.net)
 - [mangabats.com (former mangabat.com)](https://www.mangabats.com)
 - [mangabuddy.com](https://mangabuddy.com) (currently down, kept in case it comes back)
+- [mangafire.to](https://mangafire.to)
 - [Mangadex](https://mangadex.org)
 - [qimanga.com](https://qimanga.com)
+- [sushiscan.net](https://sushiscan.net) \*
 - [tcbonepiecechapters.com (TCB Scans, former tcbscans.com)](https://tcbonepiecechapters.com)
+- [toongod.org](https://www.toongod.org) \*
+- [zonatmo.org (TuMangaOnline, former zonatmo.com)](https://zonatmo.org)
 
-It may support even more sites of which I'm not aware. If you find a site that is not supported, feel free to open a new issue or a PR with the implementation.
+> \* These sites can't be scraped with plain HTTP requests (they render with
+> javascript or sit behind a Cloudflare challenge), so they need a Chromium-based
+> browser installed (Google Chrome, Chromium, Brave or Edge), which
+> manga-downloader launches automatically to render the pages. Most are behind a
+> Cloudflare challenge that only passes in a visible browser, so run them with
+> `--browser-visible` (a browser window will open, and you may need to solve a
+> challenge once):
+>
+> ~~~bash
+> manga-downloader --browser-visible https://www.toongod.org/webtoon/solo-leveling/ 1-10
+> ~~~
+
+It may support even more sites of which I'm not aware. If you find a site that
+is not supported, feel free to open a new issue or a PR with the implementation.
+
+Installation
+------------
+
+Download the archive for your system from the [releases section][releases] and
+extract it. You can then run the binary from that folder:
+
+~~~bash
+./manga-downloader
+~~~
+
+Or on Windows:
+
+~~~cmd
+.\manga-downloader.exe
+~~~
+
+To be able to run it from anywhere, place the binary in a folder that is in
+your `PATH` (or add the folder where you extracted it to your `PATH`
+environment variable). Common choices:
+
+- Linux and macOS: `/usr/local/bin`
+- Windows: `C:\Windows\System32`
+
+### macOS
+
+Since the binary is not signed, macOS's Gatekeeper will block it the first time
+you try to run it. On recent macOS versions the old terminal workarounds (like
+`spctl --master-disable`) no longer work, so you have to allow it manually:
+
+1. Run `./manga-downloader` once. macOS will show a warning saying the binary
+   could not be verified and block it.
+2. Open **System Settings** → **Privacy & Security**, scroll down to the
+   **Security** section, and you'll see a message about *manga-downloader*
+   being blocked. Click **Open Anyway** (or **Allow Anyway**).
+3. Run `./manga-downloader` again and confirm in the dialog that pops up.
+
+You only need to do this once; subsequent runs will work normally.
+
+### Windows
+
+If you place the `.exe` file inside `C:\Windows\System32` you'll be able to
+call the program from anywhere:
+
+~~~cmd
+C:\Users\elboletaire\Desktop>manga-downloader https://mangadex.org/title/e7eabe96-aa17-476f-b431-2497d5e9d060/black-clover 1-346
+~~~
+
+The above command downloads Black Clover chapters 1 to 346 to the Desktop
+folder (since that's the current directory).
+
+### Docker
+
+You can also run manga-downloader directly via Docker, without installing
+anything:
+
+~~~bash
+docker run --rm -it -v $PWD:/downloads elboletaire/manga-downloader --help
+~~~
+
+Note the `-v $PWD:/downloads` param: it's required in order to get the
+downloaded files in your current folder.
 
 Usage
 -----
 
-Only one param is required:
+Only one argument is required: the URL of the manga's index page (the page
+listing all its chapters, not an individual chapter).
 
 ~~~bash
 manga-downloader [URL]
 ~~~
 
-The URL must be a series index file (not an individual chapter).
-
-When only specifying the URL, it would ask you if you want to download all
+When you only specify the URL, it will ask you whether you want to download all
 chapters.
 
-> Note: you must specify <kbd>y</kbd> in order to download them, its default
-> behavior is set to "no".
+> Note: you must answer <kbd>y</kbd> to download them; it defaults to "no".
 
-You can also specify the range beforehand, the range allows you setting chapters by
-ranges (i.e. 1,3,5-10):
+You can also specify which chapters to download as a second argument, using
+single numbers and/or ranges separated by commas (e.g. `1,3,5-10`):
 
 ~~~bash
 manga-downloader https://inmanga.com/ver/manga/One-Piece/dfc7ecb5-e9b3-4aa5-a61b-a498993cd935 1-50
-# This would download One Piece chapters 1 to 50 into our current folder
+# downloads One Piece chapters 1 to 50 into the current folder
 ~~~
 
 ![download img]
 
-In some sites, like mangadex, it may find multiple results for the same chapter,
-given the different languages it's translated to. In these cases, every
-coincidence will be downloaded into different files, but you can force a single
-language to be downloaded by using `--language`:
+Arguments are not positional, so you can pass them in any order:
+
+~~~bash
+manga-downloader 1-50 https://inmanga.com/ver/manga/One-Piece/dfc7ecb5-e9b3-4aa5-a61b-a498993cd935
+# exactly the same as the previous example
+~~~
+
+### Choosing a language
+
+Some sites, like MangaDex, can return the same chapter multiple times, once per
+translated language. By default every match is downloaded to its own file, but
+you can restrict the download to a single language with `--language`:
 
 ~~~bash
 manga-downloader --language es https://mangadex.org/title/a1c7c817-4e59-43b7-9365-09675a149a6f/one-piece 1-10
-# would download One Piece chapters 1 to 10 in spanish
-~~~
-
-Arguments and params are not positional, you can use them in any order:
-
-~~~bash
-manga-downloader 1-10 https://mangadex.org/title/a1c7c817-4e59-43b7-9365-09675a149a6f/one-piece --language es
-# exactly the same as the previous example, only changing params order
+# downloads One Piece chapters 1 to 10 in Spanish
 ~~~
 
 ### Bundling
 
-You can bundle all the downloaded chapters into a single file by using the
-`--bundle` arg:
+Use `--bundle` to bundle all the downloaded chapters into a single CBZ file:
 
 ~~~bash
 manga-downloader https://inmanga.com/ver/manga/One-Piece/dfc7ecb5-e9b3-4aa5-a61b-a498993cd935 1-8 --bundle
-# would download one piece chapters 1 to 8 and bundle them into a single file
+# downloads One Piece chapters 1 to 8 into a single file
 ~~~
 
 ![bundle img]
 
-### Help
+### Custom file names
 
-Use the `help` command to see all the available options:
+Resulting file names can be customized with `--filename-template`, which takes
+a [Go text/template](https://pkg.go.dev/text/template) string. The available
+variables are `{{.Series}}`, `{{.Number}}`, `{{.Title}}` and `{{.Version}}`
+(a counter appended when a file name would be duplicated). The default is:
+
+~~~
+{{.Series}} {{.Number}} - {{.Title}}{{if gt .Version 1}} v{{.Version}}{{end}}
+~~~
+
+### All options
+
+| Flag                  | Short | Description                                              | Default            |
+| --------------------- | ----- | -------------------------------------------------------- | ------------------ |
+| `--bundle`            | `-b`  | Bundle all specified chapters into a single file         | off                |
+| `--language`          | `-l`  | Only download the specified language                     | all languages      |
+| `--output-dir`        | `-o`  | Output directory for the downloaded files                | current folder     |
+| `--filename-template` | `-t`  | Template for the resulting file names                    | see above          |
+| `--concurrency`       | `-c`  | Concurrent chapter downloads (max 5)                     | 5                  |
+| `--concurrency-pages` | `-C`  | Concurrent page downloads per chapter (max 10)           | 10                 |
+| `--browser-visible`   |       | Show the browser window on sites that need one           | off                |
+
+Run the `help` command to see them all from your terminal:
 
 ~~~bash
 manga-downloader help
 ~~~
 
 ![help img]
-
-Installation
-------------
-
-First download your desired version from the [releases section][releases].
-
-After you downloaded and unarchived it, you can start using it in that folder:
-
-~~~bash
-./manga-downloader URL range
-~~~
-
-For Windows users would be:
-
-~~~cmd
-.\manga-downloader URL range
-~~~
-
-If you want the binary to be accessible from your terminal in whatever path you
-might be, you should ensure to place the binary on a `PATH` defined folder (or
-add the folder where you downloaded manga-downloader to your `PATH` env var).
-
-Places where you can put the binary and have it accessible system-wide:
-
-- Linux and Mac: `/usr/local/bin`
-- Windows: `C:\Windows\System32`
-
-### Windows
-
-So if you're a windows user and place the .exe file inside `C:\Windows\System32`
-you'll be able to call the program wherever you want from:
-
-~~~bash
-C:\Users\elboletaire\Desktop>manga-downloader https://mangadex.org/title/e7eabe96-aa17-476f-b431-2497d5e9d060/black-clover 1-346
-~~~
-
-The above command would download Black Clover chapters 1 to 346 to the Desktop
-folder (since that's the current directory).
-
-### Mac
-
-Mac users will need to either add the binary to the unsigned apps whitelist, or
-entirely disable Gatekeeper:
-
-~~~bash
-sudo spctl --master-disable
-~~~
-
-Othwerise you'll see an error because the binary is unsigned.
-
-### Using Docker
-
-You can also use manga-downloader directly via docker like so:
-
-~~~bash
-docker run --rm -it -v $PWD:/downloads elboletaire/manga-downloader --help
-~~~
-
-Note the `-v $PWD:/downloads` param, that's required in order to get the downloads in your current path.
 
 Star history ![starline]
 ------------------------

--- a/browser/browser.go
+++ b/browser/browser.go
@@ -1,0 +1,173 @@
+// Package browser renders pages with a locally installed Chrome (or
+// Chromium/Brave/Edge) via chromedp, for sites that cannot be scraped with
+// plain HTTP requests: javascript-rendered chapter lists, TLS-fingerprint
+// blocks or Cloudflare challenges.
+//
+// A single browser process is started lazily on first use and shared by all
+// grabbers. After each page load the session cookies and real user agent are
+// harvested into the http package, so images can still be downloaded with
+// fast plain HTTP requests instead of through the browser.
+package browser
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/chromedp/cdproto/dom"
+	"github.com/chromedp/cdproto/network"
+	"github.com/chromedp/chromedp"
+	"github.com/elboletaire/manga-downloader/http"
+)
+
+// visible determines if the browser window is shown (headed mode). Some
+// Cloudflare challenges only pass in headed mode, where the user can also
+// solve interactive captchas manually.
+var visible bool
+
+// SetVisible toggles headed mode. Must be called before the first page fetch.
+func SetVisible(v bool) {
+	visible = v
+}
+
+var (
+	mu          sync.Mutex
+	allocCtx    context.Context
+	allocCancel context.CancelFunc
+	browserCtx  context.Context
+	browserStop context.CancelFunc
+)
+
+// ErrNoBrowser is returned when no Chrome-like browser is installed
+var ErrNoBrowser = errors.New(
+	"no Chrome-like browser found: this site needs a real browser to be scraped.\n" +
+		"Install Google Chrome (or Chromium/Brave/Edge) and try again",
+)
+
+// start boots the shared browser instance (only once)
+func start() error {
+	if browserCtx != nil {
+		return nil
+	}
+
+	opts := chromedp.DefaultExecAllocatorOptions[:]
+	if visible {
+		opts = append(opts,
+			chromedp.Flag("headless", false),
+			chromedp.Flag("start-minimized", true),
+		)
+	}
+	// reduce automation fingerprint: this flag adds navigator.webdriver etc.
+	opts = append(opts, chromedp.Flag("disable-blink-features", "AutomationControlled"))
+
+	allocCtx, allocCancel = chromedp.NewExecAllocator(context.Background(), opts...)
+	browserCtx, browserStop = chromedp.NewContext(allocCtx)
+
+	// starting the browser eagerly gives a nicer error when chrome is missing
+	if err := chromedp.Run(browserCtx); err != nil {
+		browserStop()
+		allocCancel()
+		browserCtx, allocCtx = nil, nil
+		if strings.Contains(err.Error(), "executable file not found") {
+			return ErrNoBrowser
+		}
+		return fmt.Errorf("error starting browser: %w", err)
+	}
+
+	return nil
+}
+
+// Close shuts down the shared browser instance, if it was started. Safe to
+// call multiple times, must be called before exiting or the Chrome process
+// is left behind.
+func Close() {
+	mu.Lock()
+	defer mu.Unlock()
+	if browserCtx == nil {
+		return
+	}
+	// gracefully close the browser (Cancel waits for it, browserStop doesn't)
+	chromedp.Cancel(browserCtx)
+	browserStop()
+	allocCancel()
+	browserCtx, allocCtx = nil, nil
+}
+
+// GetHTML navigates to the given URL in a new tab, waits until waitSelector
+// is visible (skipped if empty) and returns the rendered HTML. Cookies and
+// the browser user agent are copied to the http package so subsequent plain
+// HTTP requests (e.g. image downloads) reuse the browser session.
+//
+// A timeout of 0 uses a sensible default: 1 minute headless, 5 minutes in
+// visible mode (leaving time for the user to solve interactive challenges).
+func GetHTML(url, waitSelector string, timeout time.Duration) (string, error) {
+	mu.Lock()
+	defer mu.Unlock()
+
+	if timeout <= 0 {
+		timeout = time.Minute
+		if visible {
+			timeout = 5 * time.Minute
+		}
+	}
+
+	if err := start(); err != nil {
+		return "", err
+	}
+
+	// new tab sharing the browser (and thus cookies/clearance tokens)
+	tab, closeTab := chromedp.NewContext(browserCtx)
+	defer closeTab()
+	ctx, cancel := context.WithTimeout(tab, timeout)
+	defer cancel()
+
+	var html string
+	actions := []chromedp.Action{
+		chromedp.Navigate(url),
+	}
+	if waitSelector != "" {
+		actions = append(actions, chromedp.WaitVisible(waitSelector, chromedp.ByQuery))
+	}
+	actions = append(actions,
+		chromedp.ActionFunc(func(ctx context.Context) error {
+			node, err := dom.GetDocument().Do(ctx)
+			if err != nil {
+				return err
+			}
+			html, err = dom.GetOuterHTML().WithNodeID(node.NodeID).Do(ctx)
+			return err
+		}),
+		chromedp.ActionFunc(harvestSession),
+	)
+
+	if err := chromedp.Run(ctx, actions...); err != nil {
+		if ctx.Err() != nil && waitSelector != "" {
+			return "", fmt.Errorf("timed out waiting for %q at %s (the site may be blocking the browser)", waitSelector, url)
+		}
+		return "", err
+	}
+
+	return html, nil
+}
+
+// harvestSession copies the browser cookies and user agent into the http
+// package, so image downloads can go through fast plain HTTP requests
+func harvestSession(ctx context.Context) error {
+	var ua string
+	if err := chromedp.Evaluate(`navigator.userAgent`, &ua).Do(ctx); err == nil && ua != "" {
+		http.SetUserAgent(ua)
+	}
+
+	cookies, err := network.GetCookies().Do(ctx)
+	if err != nil {
+		return nil // cookies are best-effort, don't fail the whole fetch
+	}
+	for _, c := range cookies {
+		http.SetCookie(strings.TrimPrefix(c.Domain, "."), c.Name, c.Value)
+	}
+
+	return nil
+}

--- a/browser/browser.go
+++ b/browser/browser.go
@@ -33,6 +33,19 @@ func SetVisible(v bool) {
 	visible = v
 }
 
+// settle is an extra wait applied after the wait selector matches, for pages
+// that keep populating content after the first elements appear
+var settle time.Duration
+
+// SetSettle sets an extra wait after the wait selector matches
+func SetSettle(d time.Duration) {
+	settle = d
+}
+
+// NetLog, when set, is called for every network response received while
+// rendering pages. Only meant for debugging/site investigation.
+var NetLog func(url string, status int, mime string)
+
 var (
 	mu          sync.Mutex
 	allocCtx    context.Context
@@ -124,12 +137,23 @@ func GetHTML(url, waitSelector string, timeout time.Duration) (string, error) {
 	ctx, cancel := context.WithTimeout(tab, timeout)
 	defer cancel()
 
+	if NetLog != nil {
+		chromedp.ListenTarget(ctx, func(ev interface{}) {
+			if resp, ok := ev.(*network.EventResponseReceived); ok {
+				NetLog(resp.Response.URL, int(resp.Response.Status), resp.Response.MimeType)
+			}
+		})
+	}
+
 	var html string
 	actions := []chromedp.Action{
 		chromedp.Navigate(url),
 	}
 	if waitSelector != "" {
 		actions = append(actions, chromedp.WaitVisible(waitSelector, chromedp.ByQuery))
+	}
+	if settle > 0 {
+		actions = append(actions, chromedp.Sleep(settle))
 	}
 	actions = append(actions,
 		chromedp.ActionFunc(func(ctx context.Context) error {

--- a/browser/browser.go
+++ b/browser/browser.go
@@ -145,7 +145,11 @@ func GetHTML(url, waitSelector string, timeout time.Duration) (string, error) {
 
 	if err := chromedp.Run(ctx, actions...); err != nil {
 		if ctx.Err() != nil && waitSelector != "" {
-			return "", fmt.Errorf("timed out waiting for %q at %s (the site may be blocking the browser)", waitSelector, url)
+			hint := ""
+			if !visible {
+				hint = ": some protections (e.g. cloudflare) only pass in a visible browser, try again with --browser-visible"
+			}
+			return "", fmt.Errorf("timed out waiting for %q at %s%s", waitSelector, url, hint)
 		}
 		return "", err
 	}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -11,6 +11,7 @@ import (
 	"sync"
 	"syscall"
 
+	"github.com/elboletaire/manga-downloader/browser"
 	"github.com/elboletaire/manga-downloader/downloader"
 	"github.com/elboletaire/manga-downloader/grabber"
 	"github.com/elboletaire/manga-downloader/packer"
@@ -66,6 +67,10 @@ Note arguments aren't really positional, you can specify them in any order:
 
 // Run is the main function of the root command, the main downloading cmd
 func Run(cmd *cobra.Command, args []string) {
+	// ensure the shared Chrome process (if any) is killed on exit
+	defer browser.Close()
+	browser.SetVisible(settings.BrowserVisible)
+
 	s, errs := grabber.NewSite(getUrlArg(args), &settings)
 	if len(errs) > 0 {
 		color.Red("Errors testing site (a site may be down):")
@@ -75,7 +80,7 @@ func Run(cmd *cobra.Command, args []string) {
 	}
 	if s == nil {
 		color.Yellow("Site not recognised")
-		os.Exit(1)
+		exit(1)
 	}
 	s.InitFlags(cmd)
 
@@ -90,7 +95,7 @@ func Run(cmd *cobra.Command, args []string) {
 		for _, err := range errs {
 			color.Red(err.Error())
 		}
-		os.Exit(1)
+		exit(1)
 	}
 
 	chapters = chapters.SortByNumber()
@@ -108,7 +113,7 @@ func Run(cmd *cobra.Command, args []string) {
 
 		if err != nil {
 			color.Yellow("Canceled by user")
-			os.Exit(0)
+			exit(0)
 		}
 
 		rngs = []ranges.Range{{Begin: 1, End: float64(lastChapter)}}
@@ -124,7 +129,7 @@ func Run(cmd *cobra.Command, args []string) {
 
 	if len(chapters) == 0 {
 		color.Yellow("No chapters found for the specified ranges")
-		os.Exit(1)
+		exit(1)
 	}
 
 	// download chapters
@@ -279,7 +284,7 @@ func Run(cmd *cobra.Command, args []string) {
 
 	if !settings.Bundle {
 		// if we're not bundling, we're done
-		os.Exit(0)
+		exit(0)
 	}
 
 	// resort downloaded
@@ -306,7 +311,7 @@ func Run(cmd *cobra.Command, args []string) {
 
 	if err != nil {
 		color.Red(err.Error())
-		os.Exit(1)
+		exit(1)
 	}
 
 	fmt.Printf("- %s %s\n", color.GreenString("saved file"), color.HiBlackString(filename))
@@ -329,7 +334,7 @@ func Execute() {
 
 	if err := rootCmd.Execute(); err != nil {
 		fmt.Println(err)
-		os.Exit(1)
+		exit(1)
 	}
 }
 
@@ -340,14 +345,22 @@ func init() {
 	rootCmd.Flags().Uint8VarP(&settings.MaxConcurrency.Pages, "concurrency-pages", "C", 10, "number of concurrent page downloads, hard-limited to 10")
 	rootCmd.Flags().StringVarP(&settings.Language, "language", "l", "", "only download the specified language")
 	rootCmd.Flags().StringVarP(&settings.FilenameTemplate, "filename-template", "t", packer.FilenameTemplateDefault, "template for the resulting filename")
+	rootCmd.Flags().BoolVar(&settings.BrowserVisible, "browser-visible", false, "show the browser window on sites that need one (lets you solve interactive challenges manually)")
 	// set as persistent, so version command does not complain about the -o flag set via docker
 	rootCmd.PersistentFlags().StringVarP(&settings.OutputDir, "output-dir", "o", "./", "output directory for the downloaded files")
+}
+
+// exit closes the shared browser (if any was started) before exiting,
+// otherwise the Chrome process would be left running in the background
+func exit(code int) {
+	browser.Close()
+	os.Exit(code)
 }
 
 func cerr(err error, prefix string) {
 	if err != nil {
 		fmt.Println(color.RedString(prefix + err.Error()))
-		os.Exit(1)
+		exit(1)
 	}
 }
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/elboletaire/manga-downloader
 
-go 1.19
+go 1.26
 
 require (
 	github.com/PuerkitoBio/goquery v1.8.0
@@ -18,7 +18,14 @@ require (
 	github.com/VividCortex/ewma v1.2.0 // indirect
 	github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d // indirect
 	github.com/andybalholm/cascadia v1.3.1 // indirect
+	github.com/chromedp/cdproto v0.0.0-20260714215040-dc233986426f // indirect
+	github.com/chromedp/chromedp v0.16.0 // indirect
+	github.com/chromedp/sysutil v1.1.0 // indirect
 	github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e // indirect
+	github.com/go-json-experiment/json v0.0.0-20260623181947-01eb4420fa68 // indirect
+	github.com/gobwas/httphead v0.1.0 // indirect
+	github.com/gobwas/pool v0.2.1 // indirect
+	github.com/gobwas/ws v1.4.0 // indirect
 	github.com/google/go-github v17.0.0+incompatible // indirect
 	github.com/google/go-querystring v1.1.0 // indirect
 	github.com/hashicorp/go-version v1.6.0 // indirect
@@ -28,5 +35,5 @@ require (
 	github.com/mattn/go-runewidth v0.0.15 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
 	golang.org/x/net v0.21.0 // indirect
-	golang.org/x/sys v0.28.0 // indirect
+	golang.org/x/sys v0.47.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -6,6 +6,12 @@ github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d h1:licZJFw2RwpH
 github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d/go.mod h1:asat636LX7Bqt5lYEZ27JNDcqxfjdBQuJ/MM4CN/Lzo=
 github.com/andybalholm/cascadia v1.3.1 h1:nhxRkql1kdYCc8Snf7D5/D3spOX+dBgjA6u8x004T2c=
 github.com/andybalholm/cascadia v1.3.1/go.mod h1:R4bJ1UQfqADjvDa4P6HZHLh/3OxWWEqc0Sk8XGwHqvA=
+github.com/chromedp/cdproto v0.0.0-20260714215040-dc233986426f h1:0Z1zcSLEmnj2c2CmJYBqewtS6pxhB39bNWUSEUAWjgk=
+github.com/chromedp/cdproto v0.0.0-20260714215040-dc233986426f/go.mod h1:RwFsSODCtFExll+GhHM6R92SARHR3Z3oipaxLHj46C0=
+github.com/chromedp/chromedp v0.16.0 h1:rOO4deOm4CbZgBCa8mD9g2rDyIoNs0BkgvNrlbp5ouk=
+github.com/chromedp/chromedp v0.16.0/go.mod h1:rbuGKFT1vMcFcFqKfPIO1GpX/N+2s8onm2qMxZLbU5U=
+github.com/chromedp/sysutil v1.1.0 h1:PUFNv5EcprjqXZD9nJb9b/c9ibAbxiYo4exNWZyipwM=
+github.com/chromedp/sysutil v1.1.0/go.mod h1:WiThHUdltqCNKGc4gaU50XgYjwjYIhKWoHGPTUfWTJ8=
 github.com/chzyer/logex v1.1.10 h1:Swpa1K6QvQznwJRcfTfQJmTE72DqScAa40E+fbHEXEE=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e h1:fY5BOSpyZCqRo5OhCuC+XN+r/bBCmeuuJtjz+bCNIf8=
@@ -16,6 +22,14 @@ github.com/cpuguy83/go-md2man/v2 v2.0.1/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46t
 github.com/cpuguy83/go-md2man/v2 v2.0.2/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/fatih/color v1.13.0 h1:8LOYc1KYPPmyKMuN8QV2DNRWNbLo6LZ0iLs8+mlH53w=
 github.com/fatih/color v1.13.0/go.mod h1:kLAiJbzzSOZDVNGyDpeOxJ47H46qBXwg5ILebYFFOfk=
+github.com/go-json-experiment/json v0.0.0-20260623181947-01eb4420fa68 h1:KZaTBSyshWX3MP5jukJcNSuXDQTO+rNpt0J564dX/eg=
+github.com/go-json-experiment/json v0.0.0-20260623181947-01eb4420fa68/go.mod h1:tphK2c80bpPhMOI4v6bIc2xWywPfbqi1Z06+RcrMkDg=
+github.com/gobwas/httphead v0.1.0 h1:exrUm0f4YX0L7EBwZHuCF4GDp8aJfVeBrlLQrs6NqWU=
+github.com/gobwas/httphead v0.1.0/go.mod h1:O/RXo79gxV8G+RqlR/otEwx4Q36zl9rqC5u12GKvMCM=
+github.com/gobwas/pool v0.2.1 h1:xfeeEhW7pwmX8nuLVlqbzVc7udMDrwetjEv+TZIz1og=
+github.com/gobwas/pool v0.2.1/go.mod h1:q8bcK0KcYlCgd9e7WYLm9LpyS+YeLd8JVDW6WezmKEw=
+github.com/gobwas/ws v1.4.0 h1:CTaoG1tojrh4ucGPcoJFiAQUAsEWekEWvLy7GsVNqGs=
+github.com/gobwas/ws v1.4.0/go.mod h1:G3gNqMNtPppf5XUz7O4shetPpcZ1VJ7zt18dlUeakrc=
 github.com/google/go-cmp v0.5.2 h1:X2ev0eStA3AbceY54o37/0PQ/UWqKEiiO2dKL5OPaFM=
 github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-github v17.0.0+incompatible h1:N0LgJ1j65A7kfXrZnUDaYCs/Sf4rEjNlfyDHW9dolSY=
@@ -67,6 +81,8 @@ golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.28.0 h1:Fksou7UEQUWlKvIdsqzJmUmCX3cZuD2+P3XyyzwMhlA=
 golang.org/x/sys v0.28.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
+golang.org/x/sys v0.47.0 h1:o7XGOvZQCADBQQ4Y7VNq2dRWQR7JmOUW8Kxx4ZsNgWs=
+golang.org/x/sys v0.47.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/term v0.27.0 h1:WP60Sv1nlK1T6SupCHbXzSaN0b9wUmsPoRS9b61A23Q=
 golang.org/x/term v0.27.0/go.mod h1:iMsnZpn0cago0GOrHO2+Y7u7JPn5AylBrcoWkElMTSM=

--- a/grabber/inmanga.go
+++ b/grabber/inmanga.go
@@ -112,14 +112,22 @@ func (i Inmanga) FetchChapter(chap Filterable) (*Chapter, error) {
 		Language: "es",
 	}
 
-	// get pages from select, but discard one, since it's duplicated
+	// get pages from select, deduplicating by page id (the select is
+	// duplicated in the page: top and bottom navigation)
+	seen := map[string]bool{}
 	doc.Find("select.PageListClass").First().Children().Each(func(i int, s *goquery.Selection) {
+		id := s.AttrOr("value", "")
+		if id == "" || seen[id] {
+			return
+		}
+		seen[id] = true
 		num, _ := strconv.ParseInt(s.Text(), 10, 64)
 		chapter.Pages = append(chapter.Pages, Page{
 			Number: num,
-			URL:    "https://pack-yak.intomanga.com/images/manga/ms/chapter/ch/page/p/" + s.AttrOr("value", ""),
+			URL:    "https://pack-yak.intomanga.com/images/manga/ms/chapter/ch/page/p/" + id,
 		})
 	})
+	chapter.PagesCount = int64(len(chapter.Pages))
 
 	return chapter, nil
 }

--- a/grabber/mangabats.go
+++ b/grabber/mangabats.go
@@ -1,0 +1,178 @@
+package grabber
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/url"
+	"regexp"
+	"strings"
+
+	"github.com/PuerkitoBio/goquery"
+	"github.com/elboletaire/manga-downloader/http"
+)
+
+// Mangabats is a grabber for mangabats.com (former mangabat.com), which loads
+// the chapters list from a JSON API and the chapter images from js variables
+// in the reader page
+type Mangabats struct {
+	*Grabber
+	title string
+}
+
+func NewMangabats(g *Grabber) *Mangabats {
+	return &Mangabats{Grabber: g}
+}
+
+// MangabatsChapter represents a Mangabats Chapter
+type MangabatsChapter struct {
+	Chapter
+	Slug string
+}
+
+// Test returns true if the URL is a mangabats.com URL
+func (m *Mangabats) Test() (bool, error) {
+	re := regexp.MustCompile(`mangabats\.com`)
+	return re.MatchString(m.URL), nil
+}
+
+// FetchTitle fetches and returns the manga title
+func (m *Mangabats) FetchTitle() (string, error) {
+	if m.title != "" {
+		return m.title, nil
+	}
+
+	body, err := http.Get(http.RequestParams{
+		URL: m.URL,
+	})
+	if err != nil {
+		return "", err
+	}
+	defer body.Close()
+
+	doc, err := goquery.NewDocumentFromReader(body)
+	if err != nil {
+		return "", err
+	}
+
+	m.title = sanitizeTitle(doc.Find("h1").Text())
+
+	return m.title, nil
+}
+
+// FetchChapters returns the chapters of the manga
+func (m Mangabats) FetchChapters() (Filterables, []error) {
+	slug, err := m.slug()
+	if err != nil {
+		return nil, []error{err}
+	}
+
+	uri, _ := url.JoinPath(m.BaseUrl(), "api", "manga", slug, "chapters")
+	body, err := http.GetText(http.RequestParams{
+		URL:     uri,
+		Referer: m.URL,
+	})
+	if err != nil {
+		return nil, []error{err}
+	}
+
+	feed := mangabatsChaptersFeed{}
+	if err = json.Unmarshal([]byte(body), &feed); err != nil {
+		return nil, []error{err}
+	}
+
+	chapters := make(Filterables, 0, len(feed.Data.Chapters))
+	for _, c := range feed.Data.Chapters {
+		chapters = append(chapters, &MangabatsChapter{
+			Chapter{
+				Number: c.Number,
+				Title:  c.Name,
+			},
+			c.Slug,
+		})
+	}
+
+	return chapters, nil
+}
+
+// FetchChapter fetches a chapter and its pages
+func (m Mangabats) FetchChapter(f Filterable) (*Chapter, error) {
+	mchap := f.(*MangabatsChapter)
+	slug, err := m.slug()
+	if err != nil {
+		return nil, err
+	}
+
+	uri, _ := url.JoinPath(m.BaseUrl(), "manga", slug, mchap.Slug)
+	body, err := http.GetText(http.RequestParams{
+		URL:     uri,
+		Referer: m.URL,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	// images are defined in js variables: cdns hosts and relative image paths
+	cdns, err := jsStringSlice(body, "cdns")
+	if err != nil {
+		return nil, err
+	}
+	if len(cdns) == 0 {
+		return nil, errors.New("no image cdns found in the chapter page")
+	}
+	images, err := jsStringSlice(body, "chapterImages")
+	if err != nil {
+		return nil, err
+	}
+
+	chapter := &Chapter{
+		Title:      f.GetTitle(),
+		Number:     f.GetNumber(),
+		PagesCount: int64(len(images)),
+		Language:   "en",
+	}
+
+	for i, img := range images {
+		chapter.Pages = append(chapter.Pages, Page{
+			Number: int64(i + 1),
+			URL:    strings.TrimRight(cdns[0], "/") + "/" + strings.TrimLeft(img, "/"),
+		})
+	}
+
+	return chapter, nil
+}
+
+// slug returns the manga slug from the URL (i.e. "one-piece" for
+// https://www.mangabats.com/manga/one-piece)
+func (m Mangabats) slug() (string, error) {
+	re := regexp.MustCompile(`/manga/([^/]+)`)
+	matches := re.FindStringSubmatch(m.URL)
+	if len(matches) != 2 {
+		return "", fmt.Errorf("could not find manga slug in url %s", m.URL)
+	}
+	return matches[1], nil
+}
+
+// jsStringSlice extracts a js string array variable from the passed html
+func jsStringSlice(html, varname string) (values []string, err error) {
+	re := regexp.MustCompile(`var ` + varname + ` = (\[[^\]]*\]);`)
+	matches := re.FindStringSubmatch(html)
+	if len(matches) != 2 {
+		return nil, fmt.Errorf("could not find the %q variable in the chapter page", varname)
+	}
+
+	err = json.Unmarshal([]byte(matches[1]), &values)
+
+	return
+}
+
+// mangabatsChaptersFeed is the JSON feed for the chapters list
+type mangabatsChaptersFeed struct {
+	Data struct {
+		Chapters []struct {
+			Name   string  `json:"chapter_name"`
+			Slug   string  `json:"chapter_slug"`
+			Number float64 `json:"chapter_num"`
+		} `json:"chapters"`
+	} `json:"data"`
+}

--- a/grabber/mangadex.go
+++ b/grabber/mangadex.go
@@ -73,8 +73,15 @@ func (m *Mangadex) FetchTitle() (string, error) {
 		}
 	}
 
-	// fallback to english
-	m.title = body.Data.Attributes.Title["en"]
+	// fallback to english or, if not present, any other title
+	if title, ok := body.Data.Attributes.Title["en"]; ok {
+		m.title = title
+	} else {
+		for _, title := range body.Data.Attributes.Title {
+			m.title = title
+			break
+		}
+	}
 
 	return m.title, nil
 }
@@ -112,6 +119,11 @@ func (m Mangadex) FetchChapters() (chapters Filterables, errs []error) {
 		}
 
 		for _, c := range body.Data {
+			// skip pageless chapters (i.e. those hosted outside mangadex, on
+			// official publisher sites): there's nothing to download from them
+			if c.Attributes.Pages == 0 {
+				continue
+			}
 			num, _ := strconv.ParseFloat(c.Attributes.Chapter, 64)
 			chapters = append(chapters, &MangadexChapter{
 				Chapter{

--- a/grabber/mangafire.go
+++ b/grabber/mangafire.go
@@ -1,0 +1,188 @@
+package grabber
+
+import (
+	"encoding/json"
+	"fmt"
+	"regexp"
+	"strconv"
+
+	"github.com/elboletaire/manga-downloader/http"
+)
+
+// Mangafire is a grabber for mangafire.to: the site is a react SPA, but both
+// the chapters list and the chapter pages are served by their open JSON api
+type Mangafire struct {
+	*Grabber
+	title string
+}
+
+func NewMangafire(g *Grabber) *Mangafire {
+	return &Mangafire{Grabber: g}
+}
+
+// MangafireChapter represents a Mangafire Chapter
+type MangafireChapter struct {
+	Chapter
+	Id int64
+}
+
+// Test returns true if the URL is a mangafire.to series URL
+func (m *Mangafire) Test() (bool, error) {
+	re := regexp.MustCompile(`mangafire\.to/(title|manga)/`)
+	return re.MatchString(m.URL), nil
+}
+
+// FetchTitle fetches and returns the manga title
+func (m *Mangafire) FetchTitle() (string, error) {
+	if m.title != "" {
+		return m.title, nil
+	}
+
+	hid, err := m.hid()
+	if err != nil {
+		return "", err
+	}
+
+	body, err := http.GetText(http.RequestParams{
+		URL:     "https://mangafire.to/api/titles/" + hid,
+		Referer: m.URL,
+	})
+	if err != nil {
+		return "", err
+	}
+
+	feed := struct {
+		Data struct {
+			Title string `json:"title"`
+		} `json:"data"`
+	}{}
+	if err = json.Unmarshal([]byte(body), &feed); err != nil {
+		return "", err
+	}
+
+	m.title = feed.Data.Title
+
+	return m.title, nil
+}
+
+// FetchChapters returns the chapters of the manga
+func (m Mangafire) FetchChapters() (chapters Filterables, errs []error) {
+	hid, err := m.hid()
+	if err != nil {
+		return nil, []error{err}
+	}
+
+	language := m.Settings.Language
+	if language == "" {
+		language = "en"
+	}
+
+	page := 1
+	for {
+		uri := fmt.Sprintf(
+			"https://mangafire.to/api/titles/%s/chapters?language=%s&sort=number&order=asc&page=%d&limit=100",
+			hid, language, page,
+		)
+		body, err := http.GetText(http.RequestParams{
+			URL:     uri,
+			Referer: m.URL,
+		})
+		if err != nil {
+			errs = append(errs, err)
+			return
+		}
+
+		feed := mangafireChaptersFeed{}
+		if err = json.Unmarshal([]byte(body), &feed); err != nil {
+			errs = append(errs, err)
+			return
+		}
+
+		for _, c := range feed.Items {
+			title := c.Name
+			if title == "" {
+				title = "Chapter " + strconv.FormatFloat(c.Number, 'f', -1, 64)
+			}
+			chapters = append(chapters, &MangafireChapter{
+				Chapter{
+					Number:   c.Number,
+					Title:    title,
+					Language: c.Language,
+				},
+				c.Id,
+			})
+		}
+
+		if !feed.Meta.HasNext {
+			return
+		}
+		page++
+	}
+}
+
+// FetchChapter fetches a chapter and its pages
+func (m Mangafire) FetchChapter(f Filterable) (*Chapter, error) {
+	mchap := f.(*MangafireChapter)
+
+	body, err := http.GetText(http.RequestParams{
+		URL:     fmt.Sprintf("https://mangafire.to/api/chapters/%d", mchap.Id),
+		Referer: m.URL,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	feed := struct {
+		Data struct {
+			Pages []struct {
+				Url string `json:"url"`
+			} `json:"pages"`
+		} `json:"data"`
+	}{}
+	if err = json.Unmarshal([]byte(body), &feed); err != nil {
+		return nil, err
+	}
+
+	chapter := &Chapter{
+		Title:      f.GetTitle(),
+		Number:     f.GetNumber(),
+		Language:   mchap.Language,
+		PagesCount: int64(len(feed.Data.Pages)),
+	}
+	for i, p := range feed.Data.Pages {
+		chapter.Pages = append(chapter.Pages, Page{
+			Number: int64(i + 1),
+			URL:    p.Url,
+		})
+	}
+
+	return chapter, nil
+}
+
+// hid returns the title id from the URL, e.g. "dkw" for both the current
+// https://mangafire.to/title/dkw-one-piece format and the legacy
+// https://mangafire.to/manga/one-piecee.dkw one
+func (m Mangafire) hid() (string, error) {
+	re := regexp.MustCompile(`/title/([^/-]+)-`)
+	if matches := re.FindStringSubmatch(m.URL); len(matches) == 2 {
+		return matches[1], nil
+	}
+	re = regexp.MustCompile(`/manga/[^/]+\.([^/.]+)`)
+	if matches := re.FindStringSubmatch(m.URL); len(matches) == 2 {
+		return matches[1], nil
+	}
+	return "", fmt.Errorf("could not find title id in url %s", m.URL)
+}
+
+// mangafireChaptersFeed is the JSON feed for the chapters list
+type mangafireChaptersFeed struct {
+	Items []struct {
+		Id       int64   `json:"id"`
+		Number   float64 `json:"number"`
+		Name     string  `json:"name"`
+		Language string  `json:"language"`
+	} `json:"items"`
+	Meta struct {
+		HasNext bool `json:"hasNext"`
+	} `json:"meta"`
+}

--- a/grabber/mangafire_test.go
+++ b/grabber/mangafire_test.go
@@ -1,0 +1,29 @@
+package grabber
+
+import "testing"
+
+func TestMangafireHid(t *testing.T) {
+	cases := []struct {
+		url     string
+		want    string
+		wantErr bool
+	}{
+		{"https://mangafire.to/title/dkw-one-piece", "dkw", false},
+		{"https://mangafire.to/title/dkw-one-piece/chapter/9054304", "dkw", false},
+		{"https://mangafire.to/manga/one-piecee.dkw", "dkw", false}, // legacy format
+		{"https://mangafire.to/title/", "", true},
+		{"https://mangafire.to/", "", true},
+	}
+
+	for _, c := range cases {
+		m := Mangafire{Grabber: &Grabber{URL: c.url}}
+		got, err := m.hid()
+		if (err != nil) != c.wantErr {
+			t.Errorf("hid(%q) error = %v, wantErr %v", c.url, err, c.wantErr)
+			continue
+		}
+		if got != c.want {
+			t.Errorf("hid(%q) = %q, want %q", c.url, got, c.want)
+		}
+	}
+}

--- a/grabber/plainhtml.go
+++ b/grabber/plainhtml.go
@@ -77,6 +77,15 @@ func (m *PlainHTML) Test() (bool, error) {
 			ChapterTitle: "span.font-medium",
 			Image:        "img[data-page-index]",
 		},
+		// zonatmo.org (TuMangaOnline, former zonatmo.com)
+		{
+			Title:        "h1.element-title",
+			Rows:         "li.upload-link",
+			Chapter:      ".chapter-number",
+			ChapterTitle: ".chapter-number",
+			Link:         ".chapter-detail a.btn-primary",
+			Image:        "img.reader-image",
+		},
 	}
 
 	// for the same priority reasons, we need to iterate over the selectors
@@ -108,7 +117,8 @@ func (m PlainHTML) FetchTitle() (string, error) {
 func (m PlainHTML) FetchChapters() (chapters Filterables, errs []error) {
 	m.rows.Each(func(i int, s *goquery.Selection) {
 		// we need to get the chapter number from the title
-		re := regexp.MustCompile(`C(?:hapter|\.)?\s*(\d+\.?\d*)`)
+		// (accepts "Chapter 10", "Ch. 10", "C 10" and the Spanish "Capítulo 10")
+		re := regexp.MustCompile(`C(?:hapter|ap[ií]tulo|\.)?\s*(\d+\.?\d*)`)
 		chap := re.FindStringSubmatch(s.Find(m.site.Chapter).Text())
 		// if the chapter has no number, we skip it (these are usually site announcements)
 		if len(chap) == 0 {

--- a/grabber/plainhtml.go
+++ b/grabber/plainhtml.go
@@ -52,6 +52,7 @@ func (m *PlainHTML) Test() (bool, error) {
 
 	// order is important, since some sites have very similar selectors
 	selectors := []SiteSelector{
+		// mangabuddy
 		{
 			Title:        "h1",
 			Rows:         "#chapter-list > li",
@@ -60,7 +61,7 @@ func (m *PlainHTML) Test() (bool, error) {
 			Link:         "a",
 			Image:        ".chapter-image img",
 		},
-		// tcbscans.com
+		// tcbonepiecechapters.com (former tcbscans.com)
 		{
 			Title:        "h1",
 			Rows:         "main .mx-auto .grid .col-span-2 a",
@@ -68,59 +69,13 @@ func (m *PlainHTML) Test() (bool, error) {
 			ChapterTitle: ".text-gray-500",
 			Image:        "picture img",
 		},
-		// manganelo/manganato
+		// asurascans.com (former asuratoon.com)
 		{
 			Title:        "h1",
-			Rows:         "div.panel-story-chapter-list .row-content-chapter li",
-			Chapter:      "a",
-			ChapterTitle: "a",
-			Link:         "a",
-			Image:        "div.container-chapter-reader img",
-		},
-		// manganelos/mangapanda
-		{
-			Title:        "h1",
-			Rows:         "#examples div.chapter-list .row",
-			Chapter:      "a",
-			ChapterTitle: "a",
-			Link:         "a",
-			Image:        "div.container-chapter-reader img",
-		},
-		// mangakakalot
-		{
-			Title:        "h1",
-			Rows:         "div.chapter-list .row",
-			Chapter:      "a",
-			ChapterTitle: "a",
-			Link:         "a",
-			Image:        "div.container-chapter-reader img,#vungdoc img",
-		},
-		// asuratoon.com
-		{
-			Title:        "h1",
-			Rows:         "#chapterlist ul li",
-			Chapter:      ".chapternum",
-			ChapterTitle: ".chapternum",
-			Link:         "a",
-			Image:        "#readerarea img.ts-main-image",
-		},
-		// mangamonks
-		{
-			Title:        "h3.info-title",
-			Rows:         "#chapter .chapter-list li",
-			Chapter:      ".chapter-number",
-			ChapterTitle: ".chapter-number",
-			Link:         "a",
-			Image:        "#imageContainer img",
-		},
-		// toonclash
-		{
-			Title:        "h1",
-			Rows:         "ul.main.version-chap > li",
-			Chapter:      "a",
-			ChapterTitle: "a",
-			Link:         "a",
-			Image:        ".reading-content > .page-break > img",
+			Rows:         `a[data-astro-prefetch][href*="/chapter/"]`,
+			Chapter:      "span.font-medium",
+			ChapterTitle: "span.font-medium",
+			Image:        "img[data-page-index]",
 		},
 	}
 

--- a/grabber/plainhtml.go
+++ b/grabber/plainhtml.go
@@ -116,10 +116,16 @@ func (m PlainHTML) FetchTitle() (string, error) {
 // FetchChapters returns a slice of chapters
 func (m PlainHTML) FetchChapters() (chapters Filterables, errs []error) {
 	m.rows.Each(func(i int, s *goquery.Selection) {
-		// we need to get the chapter number from the title
-		// (accepts "Chapter 10", "Ch. 10", "C 10" and the Spanish "Capítulo 10")
-		re := regexp.MustCompile(`(?i)C(?:hapter|ap[ií]tulo|\.)?\s*(\d+\.?\d*)`)
+		// we need to get the chapter number from the title (accepts "Chapter 10",
+		// "C. 10", the Spanish "Capítulo 10" and the French "Chapitre 10")
+		re := regexp.MustCompile(`(?i)\bC(?:hapter|hapitre|ap[ií]tulo)?\.?\s*(\d+\.?\d*)`)
 		chap := re.FindStringSubmatch(s.Find(m.site.Chapter).Text())
+		if len(chap) == 0 {
+			// some sites (e.g. sushiscan) list volumes instead of chapters; only
+			// checked as fallback so "Vol.2 Chapter 15" still prefers the chapter
+			re = regexp.MustCompile(`(?i)\bVol(?:ume|umen)?\.?\s*(\d+\.?\d*)`)
+			chap = re.FindStringSubmatch(s.Find(m.site.Chapter).Text())
+		}
 		// if the chapter has no number, we skip it (these are usually site announcements)
 		if len(chap) == 0 {
 			return
@@ -216,6 +222,19 @@ func getPlainHTMLImageURL(selector string, doc *goquery.Document) []string {
 	pimages := doc.Find("#arraydata")
 	if pimages.Length() == 1 {
 		return strings.Split(pimages.Text(), ",")
+	}
+
+	// mangastream/themesia based readers (e.g. sushiscan) embed all the pages
+	// of the chapter in a ts_reader javascript call
+	re = regexp.MustCompile(`(?s)ts_reader\.run\(.*?"images":\s*\[(.*?)\]`)
+	matches = re.FindStringSubmatch(html)
+	if len(matches) > 1 {
+		urls := regexp.MustCompile(`"([^"]+)"`).FindAllStringSubmatch(matches[1], -1)
+		imgs := []string{}
+		for _, u := range urls {
+			imgs = append(imgs, strings.ReplaceAll(u[1], `\/`, `/`))
+		}
+		return imgs
 	}
 
 	// images are inside picture objects

--- a/grabber/plainhtml.go
+++ b/grabber/plainhtml.go
@@ -157,6 +157,11 @@ func (m PlainHTML) FetchChapter(f Filterable) (*Chapter, error) {
 		return nil, err
 	}
 
+	return m.chapterFromDoc(f, doc), nil
+}
+
+// chapterFromDoc builds a Chapter from an already parsed reader page
+func (m PlainHTML) chapterFromDoc(f Filterable, doc *goquery.Document) *Chapter {
 	pimages := getPlainHTMLImageURL(m.site.Image, doc)
 	pcount := len(pimages)
 
@@ -184,7 +189,7 @@ func (m PlainHTML) FetchChapter(f Filterable) (*Chapter, error) {
 		chapter.Pages = append(chapter.Pages, page)
 	}
 
-	return chapter, nil
+	return chapter
 }
 
 func getPlainHTMLImageURL(selector string, doc *goquery.Document) []string {

--- a/grabber/plainhtml.go
+++ b/grabber/plainhtml.go
@@ -113,30 +113,43 @@ func (m PlainHTML) FetchTitle() (string, error) {
 	return sanitizeTitle(title.Text()), nil
 }
 
+// chapterNumberRe matches a chapter number in a chapter title, accepting
+// "Chapter 10", "Ch. 10", "C. 10", the Spanish "Capítulo 10" and the French
+// "Chapitre 10" (case insensitive).
+var chapterNumberRe = regexp.MustCompile(`(?i)\b(?:chapter|chapitre|cap[ií]tulo|ch|c)\.?\s*(\d+\.?\d*)`)
+
+// volumeNumberRe matches a volume number ("Volume 18", "Vol. 2", the Spanish
+// "Volumen 3"), used as a fallback for sites that list volumes instead of
+// chapters (e.g. sushiscan).
+var volumeNumberRe = regexp.MustCompile(`(?i)\bvol(?:ume|umen)?\.?\s*(\d+\.?\d*)`)
+
+// parseChapterNumber extracts the chapter number from a chapter title, falling
+// back to a volume number. Returns false if no number could be found (these
+// are usually site announcements rather than actual chapters).
+func parseChapterNumber(text string) (float64, bool) {
+	match := chapterNumberRe.FindStringSubmatch(text)
+	if len(match) == 0 {
+		// only checked as fallback so "Vol.2 Chapter 15" still prefers the chapter
+		match = volumeNumberRe.FindStringSubmatch(text)
+	}
+	if len(match) == 0 {
+		return 0, false
+	}
+	number, err := strconv.ParseFloat(match[1], 64)
+	if err != nil {
+		return 0, false
+	}
+	return number, true
+}
+
 // FetchChapters returns a slice of chapters
 func (m PlainHTML) FetchChapters() (chapters Filterables, errs []error) {
 	m.rows.Each(func(i int, s *goquery.Selection) {
-		// we need to get the chapter number from the title (accepts "Chapter 10",
-		// "C. 10", the Spanish "Capítulo 10" and the French "Chapitre 10")
-		re := regexp.MustCompile(`(?i)\bC(?:hapter|hapitre|ap[ií]tulo)?\.?\s*(\d+\.?\d*)`)
-		chap := re.FindStringSubmatch(s.Find(m.site.Chapter).Text())
-		if len(chap) == 0 {
-			// some sites (e.g. sushiscan) list volumes instead of chapters; only
-			// checked as fallback so "Vol.2 Chapter 15" still prefers the chapter
-			re = regexp.MustCompile(`(?i)\bVol(?:ume|umen)?\.?\s*(\d+\.?\d*)`)
-			chap = re.FindStringSubmatch(s.Find(m.site.Chapter).Text())
-		}
-		// if the chapter has no number, we skip it (these are usually site announcements)
-		if len(chap) == 0 {
+		number, ok := parseChapterNumber(s.Find(m.site.Chapter).Text())
+		if !ok {
 			return
 		}
 
-		num := chap[1]
-		number, err := strconv.ParseFloat(num, 64)
-		if err != nil {
-			errs = append(errs, err)
-			return
-		}
 		u := s.AttrOr("href", "")
 		if m.site.Link != "" {
 			u = s.Find(m.site.Link).AttrOr("href", "")

--- a/grabber/plainhtml.go
+++ b/grabber/plainhtml.go
@@ -118,7 +118,7 @@ func (m PlainHTML) FetchChapters() (chapters Filterables, errs []error) {
 	m.rows.Each(func(i int, s *goquery.Selection) {
 		// we need to get the chapter number from the title
 		// (accepts "Chapter 10", "Ch. 10", "C 10" and the Spanish "Capítulo 10")
-		re := regexp.MustCompile(`C(?:hapter|ap[ií]tulo|\.)?\s*(\d+\.?\d*)`)
+		re := regexp.MustCompile(`(?i)C(?:hapter|ap[ií]tulo|\.)?\s*(\d+\.?\d*)`)
 		chap := re.FindStringSubmatch(s.Find(m.site.Chapter).Text())
 		// if the chapter has no number, we skip it (these are usually site announcements)
 		if len(chap) == 0 {

--- a/grabber/plainhtml_test.go
+++ b/grabber/plainhtml_test.go
@@ -1,0 +1,113 @@
+package grabber
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/PuerkitoBio/goquery"
+)
+
+func TestParseChapterNumber(t *testing.T) {
+	cases := []struct {
+		in     string
+		want   float64
+		wantOk bool
+	}{
+		{"Chapter 10", 10, true},
+		{"chapter 290", 290, true}, // lowercase (dragontea)
+		{"Chapter 10.5", 10.5, true},
+		{"Ch. 5", 5, true},
+		{"C. 12", 12, true},
+		{"Capítulo 1188", 1188, true}, // spanish, accented (zonatmo)
+		{"Capitulo 7", 7, true},       // spanish, no accent
+		{"Chapitre 42", 42, true},     // french (sushiscan)
+		{"  Chapter   3  ", 3, true},  // surrounding/inner whitespace
+		{"Volume 18", 18, true},       // volume fallback (sushiscan)
+		{"Vol. 2", 2, true},
+		{"Vol.2 Chapter 15", 15, true}, // chapter preferred over volume
+		{"Notice", 0, false},           // announcements have no number
+		{"", 0, false},
+	}
+
+	for _, c := range cases {
+		got, ok := parseChapterNumber(c.in)
+		if ok != c.wantOk || (ok && got != c.want) {
+			t.Errorf("parseChapterNumber(%q) = (%v, %v), want (%v, %v)", c.in, got, ok, c.want, c.wantOk)
+		}
+	}
+}
+
+func docFromHTML(t *testing.T, html string) *goquery.Document {
+	t.Helper()
+	doc, err := goquery.NewDocumentFromReader(strings.NewReader(html))
+	if err != nil {
+		t.Fatalf("could not parse html: %v", err)
+	}
+	return doc
+}
+
+func TestGetPlainHTMLImageURL(t *testing.T) {
+	cases := []struct {
+		name     string
+		selector string
+		html     string
+		want     []string
+	}{
+		{
+			name:     "chapImages javascript variable",
+			selector: "img",
+			html:     `<html><body><script>var chapImages = 'https://a.co/1.jpg,https://a.co/2.jpg'</script></body></html>`,
+			want:     []string{"https://a.co/1.jpg", "https://a.co/2.jpg"},
+		},
+		{
+			name:     "arraydata hidden layer",
+			selector: "img",
+			html:     `<html><body><div id="arraydata">https://a.co/1.jpg,https://a.co/2.jpg</div></body></html>`,
+			want:     []string{"https://a.co/1.jpg", "https://a.co/2.jpg"},
+		},
+		{
+			name:     "ts_reader javascript call (sushiscan)",
+			selector: "#readerarea img",
+			html:     `<html><body><script>ts_reader.run({"post_id":1,"sources":[{"source":"Server 1","images":["https:\/\/a.co\/1.jpg","https:\/\/a.co\/2.jpg"]}]});</script></body></html>`,
+			want:     []string{"https://a.co/1.jpg", "https://a.co/2.jpg"},
+		},
+		{
+			name:     "plain img src",
+			selector: "div.reading-content img",
+			html:     `<html><body><div class="reading-content"><img src="https://a.co/1.jpg"/><img src="https://a.co/2.jpg"/></div></body></html>`,
+			want:     []string{"https://a.co/1.jpg", "https://a.co/2.jpg"},
+		},
+		{
+			name:     "data-src fallback when src is a data uri",
+			selector: "div.reading-content img",
+			html:     `<html><body><div class="reading-content"><img src="data:image/gif;base64,abc" data-src="https://a.co/1.jpg"/></div></body></html>`,
+			want:     []string{"https://a.co/1.jpg"},
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := getPlainHTMLImageURL(c.selector, docFromHTML(t, c.html))
+			if !reflect.DeepEqual(got, c.want) {
+				t.Errorf("getPlainHTMLImageURL() = %v, want %v", got, c.want)
+			}
+		})
+	}
+}
+
+func TestSanitizeTitle(t *testing.T) {
+	cases := []struct {
+		in   string
+		want string
+	}{
+		{"  One   Piece  ", "One Piece"},
+		{"One\n\tPiece", "One Piece"},
+		{"One Piece", "One Piece"},
+	}
+	for _, c := range cases {
+		if got := sanitizeTitle(c.in); got != c.want {
+			t.Errorf("sanitizeTitle(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}

--- a/grabber/plainhtmlbrowser.go
+++ b/grabber/plainhtmlbrowser.go
@@ -56,6 +56,22 @@ var browserSelectors = []BrowserSiteSelector{
 		ChaptersWait: `a[href*="/reader/"]`,
 		ImageWait:    `img[alt^="Page"]`,
 	},
+	// sushiscan.net (french): mangastream/themesia theme behind a cloudflare
+	// challenge, usually needs --browser-visible. All the reader pages come
+	// from the embedded ts_reader javascript call.
+	{
+		SiteSelector: SiteSelector{
+			Title:        "h1.entry-title",
+			Rows:         "#chapterlist li",
+			Chapter:      ".chapternum",
+			ChapterTitle: ".chapternum",
+			Link:         "a",
+			Image:        "#readerarea img",
+		},
+		Domains:      []string{"sushiscan.net"},
+		ChaptersWait: "#chapterlist li",
+		ImageWait:    "#readerarea img",
+	},
 }
 
 // PlainHTMLBrowser is the browser-rendered variant of PlainHTML: pages are

--- a/grabber/plainhtmlbrowser.go
+++ b/grabber/plainhtmlbrowser.go
@@ -42,6 +42,20 @@ var browserSelectors = []BrowserSiteSelector{
 		ChaptersWait: "li.wp-manga-chapter",
 		ImageWait:    "div.reading-content",
 	},
+	// kappabeast.com: react SPA behind a cloudflare challenge, usually
+	// needs --browser-visible. Images are hosted on blogger/strapi CDNs.
+	{
+		SiteSelector: SiteSelector{
+			Title:        "h1",
+			Rows:         `a[href*="/reader/"]`,
+			Chapter:      "h4",
+			ChapterTitle: "p",
+			Image:        `img[alt^="Page"]`,
+		},
+		Domains:      []string{"kappabeast.com"},
+		ChaptersWait: `a[href*="/reader/"]`,
+		ImageWait:    `img[alt^="Page"]`,
+	},
 }
 
 // PlainHTMLBrowser is the browser-rendered variant of PlainHTML: pages are

--- a/grabber/plainhtmlbrowser.go
+++ b/grabber/plainhtmlbrowser.go
@@ -1,0 +1,100 @@
+package grabber
+
+import (
+	"net/url"
+	"strings"
+
+	"github.com/PuerkitoBio/goquery"
+	"github.com/elboletaire/manga-downloader/browser"
+	"github.com/fatih/color"
+)
+
+// BrowserSiteSelector is a SiteSelector for sites that need a real browser
+// (javascript rendering, TLS-fingerprint blocks or cloudflare challenges).
+// Unlike plain SiteSelector entries, these are matched by domain instead of
+// by fetching the page, since starting a browser is expensive.
+type BrowserSiteSelector struct {
+	SiteSelector
+	// Domains that this selector applies to (matched without the www. prefix)
+	Domains []string
+	// ChaptersWait is the CSS selector to wait for on the series page
+	ChaptersWait string
+	// ImageWait is the CSS selector to wait for on the reader page
+	ImageWait string
+}
+
+// browserSelectors is the list of sites that need browser rendering. Their
+// series & reader pages are rendered in Chrome, but images are downloaded
+// via plain HTTP reusing the browser cookies & user agent.
+var browserSelectors = []BrowserSiteSelector{}
+
+// PlainHTMLBrowser is the browser-rendered variant of PlainHTML: pages are
+// fetched with a local Chrome instead of plain HTTP requests, then parsed
+// with the same selector-driven logic.
+type PlainHTMLBrowser struct {
+	*PlainHTML
+	selector BrowserSiteSelector
+}
+
+// NewPlainHTMLBrowser returns a new PlainHTMLBrowser grabber
+func NewPlainHTMLBrowser(g *Grabber) *PlainHTMLBrowser {
+	return &PlainHTMLBrowser{PlainHTML: NewPlainHTML(g)}
+}
+
+// Test matches the URL against the registered browser-based site domains and,
+// on match, renders the series page in the browser
+func (m *PlainHTMLBrowser) Test() (bool, error) {
+	u, err := url.Parse(m.URL)
+	if err != nil {
+		return false, err
+	}
+	host := strings.TrimPrefix(u.Hostname(), "www.")
+
+	matched := false
+	for _, selector := range browserSelectors {
+		for _, domain := range selector.Domains {
+			if host == domain {
+				m.selector = selector
+				m.site = selector.SiteSelector
+				matched = true
+				break
+			}
+		}
+		if matched {
+			break
+		}
+	}
+	if !matched {
+		return false, nil
+	}
+
+	color.Blue("this site needs a real browser, launching Chrome (may take a few seconds)...")
+	html, err := browser.GetHTML(m.URL, m.selector.ChaptersWait, 0)
+	if err != nil {
+		return false, err
+	}
+
+	m.doc, err = goquery.NewDocumentFromReader(strings.NewReader(html))
+	if err != nil {
+		return false, err
+	}
+	m.rows = m.doc.Find(m.site.Rows)
+
+	return m.rows.Length() > 0, nil
+}
+
+// FetchChapter renders the reader page in the browser and extracts its pages
+func (m *PlainHTMLBrowser) FetchChapter(f Filterable) (*Chapter, error) {
+	chap := f.(*PlainHTMLChapter)
+
+	html, err := browser.GetHTML(chap.URL, m.selector.ImageWait, 0)
+	if err != nil {
+		return nil, err
+	}
+	doc, err := goquery.NewDocumentFromReader(strings.NewReader(html))
+	if err != nil {
+		return nil, err
+	}
+
+	return m.chapterFromDoc(f, doc), nil
+}

--- a/grabber/plainhtmlbrowser.go
+++ b/grabber/plainhtmlbrowser.go
@@ -87,6 +87,20 @@ func NewPlainHTMLBrowser(g *Grabber) *PlainHTMLBrowser {
 	return &PlainHTMLBrowser{PlainHTML: NewPlainHTML(g)}
 }
 
+// matchBrowserSelector returns the registered browser selector for the given
+// host (matched without the www. prefix), if any
+func matchBrowserSelector(host string) (BrowserSiteSelector, bool) {
+	host = strings.TrimPrefix(host, "www.")
+	for _, selector := range browserSelectors {
+		for _, domain := range selector.Domains {
+			if host == domain {
+				return selector, true
+			}
+		}
+	}
+	return BrowserSiteSelector{}, false
+}
+
 // Test matches the URL against the registered browser-based site domains and,
 // on match, renders the series page in the browser
 func (m *PlainHTMLBrowser) Test() (bool, error) {
@@ -96,23 +110,12 @@ func (m *PlainHTMLBrowser) Test() (bool, error) {
 	}
 	host := strings.TrimPrefix(u.Hostname(), "www.")
 
-	matched := false
-	for _, selector := range browserSelectors {
-		for _, domain := range selector.Domains {
-			if host == domain {
-				m.selector = selector
-				m.site = selector.SiteSelector
-				matched = true
-				break
-			}
-		}
-		if matched {
-			break
-		}
-	}
+	selector, matched := matchBrowserSelector(host)
 	if !matched {
 		return false, nil
 	}
+	m.selector = selector
+	m.site = selector.SiteSelector
 
 	color.Blue("this site needs a real browser, launching Chrome (may take a few seconds)...")
 	html, err := browser.GetHTML(m.URL, m.selector.ChaptersWait, 0)

--- a/grabber/plainhtmlbrowser.go
+++ b/grabber/plainhtmlbrowser.go
@@ -27,7 +27,8 @@ type BrowserSiteSelector struct {
 // series & reader pages are rendered in Chrome, but images are downloaded
 // via plain HTTP reusing the browser cookies & user agent.
 var browserSelectors = []BrowserSiteSelector{
-	// toongod.org: cloudflare challenge, usually needs --browser-visible
+	// Madara-based wordpress sites behind a cloudflare challenge, they
+	// usually need --browser-visible
 	{
 		SiteSelector: SiteSelector{
 			Title:        "div.post-title h1",
@@ -37,7 +38,7 @@ var browserSelectors = []BrowserSiteSelector{
 			Link:         "a",
 			Image:        "div.reading-content img",
 		},
-		Domains:      []string{"toongod.org"},
+		Domains:      []string{"toongod.org", "dragontea.ink"},
 		ChaptersWait: "li.wp-manga-chapter",
 		ImageWait:    "div.reading-content",
 	},

--- a/grabber/plainhtmlbrowser.go
+++ b/grabber/plainhtmlbrowser.go
@@ -117,6 +117,12 @@ func (m *PlainHTMLBrowser) Test() (bool, error) {
 	color.Blue("this site needs a real browser, launching Chrome (may take a few seconds)...")
 	html, err := browser.GetHTML(m.URL, m.selector.ChaptersWait, 0)
 	if err != nil {
+		// the domain matched, so this IS the right grabber: make the failure
+		// actionable instead of letting it fall through to "site not recognised"
+		if !m.Settings.BrowserVisible {
+			color.Yellow("could not load %s in a headless browser (it's likely behind a challenge).", host)
+			color.Yellow("re-run the same command adding --browser-visible to solve it in a visible window.")
+		}
 		return false, err
 	}
 

--- a/grabber/plainhtmlbrowser.go
+++ b/grabber/plainhtmlbrowser.go
@@ -26,7 +26,22 @@ type BrowserSiteSelector struct {
 // browserSelectors is the list of sites that need browser rendering. Their
 // series & reader pages are rendered in Chrome, but images are downloaded
 // via plain HTTP reusing the browser cookies & user agent.
-var browserSelectors = []BrowserSiteSelector{}
+var browserSelectors = []BrowserSiteSelector{
+	// toongod.org: cloudflare challenge, usually needs --browser-visible
+	{
+		SiteSelector: SiteSelector{
+			Title:        "div.post-title h1",
+			Rows:         "li.wp-manga-chapter",
+			Chapter:      "a",
+			ChapterTitle: "a",
+			Link:         "a",
+			Image:        "div.reading-content img",
+		},
+		Domains:      []string{"toongod.org"},
+		ChaptersWait: "li.wp-manga-chapter",
+		ImageWait:    "div.reading-content",
+	},
+}
 
 // PlainHTMLBrowser is the browser-rendered variant of PlainHTML: pages are
 // fetched with a local Chrome instead of plain HTTP requests, then parsed

--- a/grabber/plainhtmlbrowser_test.go
+++ b/grabber/plainhtmlbrowser_test.go
@@ -1,0 +1,41 @@
+package grabber
+
+import "testing"
+
+func TestMatchBrowserSelector(t *testing.T) {
+	cases := []struct {
+		host      string
+		wantMatch bool
+	}{
+		{"toongod.org", true},
+		{"www.toongod.org", true}, // www. prefix is stripped
+		{"dragontea.ink", true},
+		{"kappabeast.com", true},
+		{"sushiscan.net", true},
+		{"example.com", false},
+		{"notatoongod.org", false}, // must be an exact host match
+	}
+
+	for _, c := range cases {
+		_, ok := matchBrowserSelector(c.host)
+		if ok != c.wantMatch {
+			t.Errorf("matchBrowserSelector(%q) matched = %v, want %v", c.host, ok, c.wantMatch)
+		}
+	}
+}
+
+// TestBrowserSelectorsAreComplete guards against a selector entry missing the
+// fields the grabber relies on.
+func TestBrowserSelectorsAreComplete(t *testing.T) {
+	for _, s := range browserSelectors {
+		if len(s.Domains) == 0 {
+			t.Error("a browser selector has no domains")
+		}
+		if s.Title == "" || s.Rows == "" || s.Image == "" {
+			t.Errorf("browser selector for %v is missing a required selector", s.Domains)
+		}
+		if s.ChaptersWait == "" || s.ImageWait == "" {
+			t.Errorf("browser selector for %v is missing a wait selector", s.Domains)
+		}
+	}
+}

--- a/grabber/qimanga.go
+++ b/grabber/qimanga.go
@@ -1,0 +1,175 @@
+package grabber
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"github.com/PuerkitoBio/goquery"
+	"github.com/elboletaire/manga-downloader/http"
+)
+
+// Qimanga is a grabber for qimanga.com: the reader pages are server side
+// rendered, but the series page only renders the newest chapters, so the
+// full chapters list needs to be fetched from their paginated JSON api
+type Qimanga struct {
+	*Grabber
+	title string
+}
+
+func NewQimanga(g *Grabber) *Qimanga {
+	return &Qimanga{Grabber: g}
+}
+
+// QimangaChapter represents a Qimanga Chapter
+type QimangaChapter struct {
+	Chapter
+	Slug string
+}
+
+// Test returns true if the URL is a qimanga.com URL
+func (q *Qimanga) Test() (bool, error) {
+	re := regexp.MustCompile(`qimanga\.com`)
+	return re.MatchString(q.URL), nil
+}
+
+// FetchTitle fetches and returns the manga title
+func (q *Qimanga) FetchTitle() (string, error) {
+	if q.title != "" {
+		return q.title, nil
+	}
+
+	body, err := http.Get(http.RequestParams{
+		URL: q.URL,
+	})
+	if err != nil {
+		return "", err
+	}
+	defer body.Close()
+
+	doc, err := goquery.NewDocumentFromReader(body)
+	if err != nil {
+		return "", err
+	}
+
+	q.title = sanitizeTitle(doc.Find("h1.series-title").First().Text())
+
+	return q.title, nil
+}
+
+// FetchChapters returns the chapters of the manga
+func (q Qimanga) FetchChapters() (chapters Filterables, errs []error) {
+	slug, err := q.seriesSlug()
+	if err != nil {
+		return nil, []error{err}
+	}
+
+	page := 1
+	for {
+		uri := fmt.Sprintf("https://api.qimanga.com/api/v1/series/%s/chapters?page=%d", slug, page)
+		body, err := http.GetText(http.RequestParams{
+			URL:     uri,
+			Referer: q.URL,
+		})
+		if err != nil {
+			errs = append(errs, err)
+			return
+		}
+
+		feed := qimangaChaptersFeed{}
+		if err = json.Unmarshal([]byte(body), &feed); err != nil {
+			errs = append(errs, err)
+			return
+		}
+		if len(feed.Data) == 0 {
+			return
+		}
+
+		for _, c := range feed.Data {
+			title := c.Title
+			if title == "" {
+				title = "Chapter " + strconv.FormatFloat(c.Number, 'f', -1, 64)
+			}
+			chapters = append(chapters, &QimangaChapter{
+				Chapter{
+					Number: c.Number,
+					Title:  title,
+				},
+				c.Slug,
+			})
+		}
+
+		if page >= feed.TotalPages {
+			return
+		}
+		page++
+	}
+}
+
+// FetchChapter fetches a chapter and its pages
+func (q Qimanga) FetchChapter(f Filterable) (*Chapter, error) {
+	qchap := f.(*QimangaChapter)
+	slug, err := q.seriesSlug()
+	if err != nil {
+		return nil, err
+	}
+
+	uri, _ := url.JoinPath(q.BaseUrl(), "series", slug, qchap.Slug)
+	body, err := http.Get(http.RequestParams{
+		URL:     uri,
+		Referer: q.URL,
+	})
+	if err != nil {
+		return nil, err
+	}
+	defer body.Close()
+
+	doc, err := goquery.NewDocumentFromReader(body)
+	if err != nil {
+		return nil, err
+	}
+
+	chapter := &Chapter{
+		Title:    f.GetTitle(),
+		Number:   f.GetNumber(),
+		Language: "en",
+	}
+
+	doc.Find("img.r-page-img").Each(func(i int, s *goquery.Selection) {
+		src := strings.TrimSpace(s.AttrOr("src", ""))
+		if src == "" {
+			return
+		}
+		chapter.Pages = append(chapter.Pages, Page{
+			Number: int64(i + 1),
+			URL:    src,
+		})
+	})
+	chapter.PagesCount = int64(len(chapter.Pages))
+
+	return chapter, nil
+}
+
+// seriesSlug returns the series slug from the URL (i.e. "1234-some-manga"
+// for https://qimanga.com/series/1234-some-manga)
+func (q Qimanga) seriesSlug() (string, error) {
+	re := regexp.MustCompile(`/series/([^/]+)`)
+	matches := re.FindStringSubmatch(q.URL)
+	if len(matches) != 2 {
+		return "", fmt.Errorf("could not find series slug in url %s", q.URL)
+	}
+	return matches[1], nil
+}
+
+// qimangaChaptersFeed is the JSON feed for the chapters list
+type qimangaChaptersFeed struct {
+	Data []struct {
+		Slug   string  `json:"slug"`
+		Number float64 `json:"number"`
+		Title  string  `json:"title"`
+	} `json:"data"`
+	TotalPages int `json:"totalPages"`
+}

--- a/grabber/site.go
+++ b/grabber/site.go
@@ -72,6 +72,7 @@ func (g *Grabber) IdentifySite() (Site, []error) {
 		NewInmanga(g),
 		NewMangadex(g),
 		NewMangabats(g),
+		NewQimanga(g),
 		NewTcb(g),
 	}
 	var errs []error

--- a/grabber/site.go
+++ b/grabber/site.go
@@ -77,6 +77,7 @@ func (g *Grabber) IdentifySite() (Site, []error) {
 		NewInmanga(g),
 		NewMangadex(g),
 		NewMangabats(g),
+		NewMangafire(g),
 		NewQimanga(g),
 		NewTcb(g),
 	}

--- a/grabber/site.go
+++ b/grabber/site.go
@@ -33,6 +33,9 @@ type Settings struct {
 	Range string
 	// OutputDir is the output directory for the downloaded files
 	OutputDir string
+	// BrowserVisible shows the browser window for sites that need one, so
+	// interactive challenges (e.g. cloudflare) can be solved manually
+	BrowserVisible bool
 }
 
 // MaxConcurrency is the max concurrency for a site
@@ -68,6 +71,8 @@ type Site interface {
 // IdentifySite returns the site passing the Test() for the specified url
 func (g *Grabber) IdentifySite() (Site, []error) {
 	sites := []Site{
+		// PlainHTMLBrowser matches by domain (no fetch), so it goes first
+		NewPlainHTMLBrowser(g),
 		NewPlainHTML(g),
 		NewInmanga(g),
 		NewMangadex(g),

--- a/grabber/site.go
+++ b/grabber/site.go
@@ -71,6 +71,7 @@ func (g *Grabber) IdentifySite() (Site, []error) {
 		NewPlainHTML(g),
 		NewInmanga(g),
 		NewMangadex(g),
+		NewMangabats(g),
 		NewTcb(g),
 	}
 	var errs []error

--- a/grabber/tcb.go
+++ b/grabber/tcb.go
@@ -11,7 +11,7 @@ import (
 	"github.com/fatih/color"
 )
 
-// Tcb is a grabber for tcbscans.com (and possibly other wordpress sites)
+// Tcb is a grabber for Madara-based wordpress sites (i.e. lhtranslation.net)
 type Tcb struct {
 	*Grabber
 	chaps *goquery.Selection

--- a/http/request.go
+++ b/http/request.go
@@ -41,7 +41,10 @@ func request(t string, params Params) (body io.ReadCloser, err error) {
 	client := &http.Client{Transport: tr}
 
 	req, _ := http.NewRequest(t, params.GetURL(), nil)
-	req.Header.Set("User-Agent", userAgent)
+	req.Header.Set("User-Agent", sessionUserAgent(userAgent))
+	if cookies := sessionCookies(req.URL.Hostname()); cookies != "" {
+		req.Header.Set("Cookie", cookies)
+	}
 	// some WAFs (e.g. ddos-guard) reject requests missing these browser headers
 	req.Header.Set("Accept", "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,*/*;q=0.8")
 	req.Header.Set("Accept-Language", "en-US,en;q=0.9")

--- a/http/request.go
+++ b/http/request.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 )
 
 // Params is an interface for request parameters
@@ -28,6 +29,10 @@ func (r RequestParams) GetReferer() string {
 	return r.Referer
 }
 
+// userAgent is sent with every request: some sites block Go's default
+// "Go-http-client" user agent with a 403/500
+const userAgent = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0 Safari/537.36"
+
 // request sends a request to the given URL
 func request(t string, params Params) (body io.ReadCloser, err error) {
 	tr := &http.Transport{
@@ -36,8 +41,17 @@ func request(t string, params Params) (body io.ReadCloser, err error) {
 	client := &http.Client{Transport: tr}
 
 	req, _ := http.NewRequest(t, params.GetURL(), nil)
-	if params.GetReferer() != "" {
-		req.Header.Add("Referer", params.GetReferer())
+	req.Header.Set("User-Agent", userAgent)
+	// some WAFs (e.g. ddos-guard) reject requests missing these browser headers
+	req.Header.Set("Accept", "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,*/*;q=0.8")
+	req.Header.Set("Accept-Language", "en-US,en;q=0.9")
+	if ref := params.GetReferer(); ref != "" {
+		// browsers always send at least the root path in the referer; some
+		// image cdns reject referers without it
+		if u, err := url.Parse(ref); err == nil && u.Path == "" {
+			ref += "/"
+		}
+		req.Header.Add("Referer", ref)
 	}
 
 	resp, err := client.Do(req)

--- a/http/session.go
+++ b/http/session.go
@@ -1,0 +1,67 @@
+package http
+
+import (
+	"strings"
+	"sync"
+)
+
+// session holds cookies and user agent harvested from the browser package,
+// so plain HTTP requests can reuse the browser session (e.g. cloudflare
+// clearance cookies tied to the browser's user agent)
+var session = struct {
+	sync.RWMutex
+	userAgent string
+	// cookies per registrable domain: domain -> name -> value
+	cookies map[string]map[string]string
+}{
+	cookies: map[string]map[string]string{},
+}
+
+// SetUserAgent overrides the user agent sent with every request. Cloudflare
+// clearance cookies are only valid with the exact user agent that solved the
+// challenge, so both must be set together.
+func SetUserAgent(ua string) {
+	session.Lock()
+	defer session.Unlock()
+	session.userAgent = ua
+}
+
+// SetCookie stores a cookie to be sent with requests to the given domain and
+// its subdomains
+func SetCookie(domain, name, value string) {
+	session.Lock()
+	defer session.Unlock()
+	if session.cookies[domain] == nil {
+		session.cookies[domain] = map[string]string{}
+	}
+	session.cookies[domain][name] = value
+}
+
+// sessionUserAgent returns the harvested user agent, or fallback if none
+func sessionUserAgent(fallback string) string {
+	session.RLock()
+	defer session.RUnlock()
+	if session.userAgent != "" {
+		return session.userAgent
+	}
+	return fallback
+}
+
+// sessionCookies returns the "name=value; ..." cookie header for a host, or
+// an empty string if there are no cookies for it
+func sessionCookies(host string) string {
+	session.RLock()
+	defer session.RUnlock()
+
+	pairs := []string{}
+	for domain, cookies := range session.cookies {
+		if host != domain && !strings.HasSuffix(host, "."+domain) {
+			continue
+		}
+		for name, value := range cookies {
+			pairs = append(pairs, name+"="+value)
+		}
+	}
+
+	return strings.Join(pairs, "; ")
+}

--- a/makefile
+++ b/makefile
@@ -33,7 +33,7 @@ else
 	go test -v ./...
 endif
 
-grabber: grabber/inmanga grabber/mangadex grabber/mangabats grabber/qimanga grabber/tcb grabber/html
+grabber: grabber/inmanga grabber/mangadex grabber/mangabats grabber/mangafire grabber/qimanga grabber/tcb grabber/html
 
 grabber/inmanga:
 	go run . https://inmanga.com/ver/manga/One-Piece/dfc7ecb5-e9b3-4aa5-a61b-a498993cd935 1187
@@ -44,6 +44,9 @@ grabber/mangadex:
 grabber/mangabats:
 	go run . https://www.mangabats.com/manga/after-the-possessor-left 1
 
+grabber/mangafire:
+	go run . https://mangafire.to/title/dkw-one-piece 1187
+
 grabber/qimanga:
 	go run . https://qimanga.com/series/4190634673-eleceed 2
 
@@ -52,8 +55,20 @@ grabber/tcb:
 
 # sites needing a real browser: not part of the `grabber` target since they
 # open a Chrome window and may require solving an interactive challenge
-grabber/browser:
+# (cloudflare). Run them one by one and solve the challenge if prompted.
+grabber/browser: grabber/toongod grabber/dragontea grabber/kappabeast grabber/sushiscan
+
+grabber/toongod:
 	go run . --browser-visible https://www.toongod.org/webtoon/solo-leveling/ 200
+
+grabber/dragontea:
+	go run . --browser-visible https://dragontea.ink/novel/it-all-starts-with-trillions-of-nether-currency/ 290
+
+grabber/kappabeast:
+	go run . --browser-visible https://kappabeast.com/series/tekkarian 2
+
+grabber/sushiscan:
+	go run . --browser-visible https://sushiscan.net/catalogue/mushoku-tensei/ 17
 
 grabber/html:
 	go run . https://tcbonepiecechapters.com/mangas/5/one-piece 1100

--- a/makefile
+++ b/makefile
@@ -53,3 +53,4 @@ grabber/tcb:
 grabber/html:
 	go run . https://tcbonepiecechapters.com/mangas/5/one-piece 1100
 	go run . https://asurascans.com/comics/absolute-regression-f886a8af 1
+	go run . https://zonatmo.org/library/manga/31322/one-piece 1188

--- a/makefile
+++ b/makefile
@@ -33,7 +33,7 @@ else
 	go test -v ./...
 endif
 
-grabber: grabber/inmanga grabber/mangadex grabber/mangabats grabber/tcb grabber/html
+grabber: grabber/inmanga grabber/mangadex grabber/mangabats grabber/qimanga grabber/tcb grabber/html
 
 grabber/inmanga:
 	go run . https://inmanga.com/ver/manga/One-Piece/dfc7ecb5-e9b3-4aa5-a61b-a498993cd935 1187
@@ -43,6 +43,9 @@ grabber/mangadex:
 
 grabber/mangabats:
 	go run . https://www.mangabats.com/manga/after-the-possessor-left 1
+
+grabber/qimanga:
+	go run . https://qimanga.com/series/4190634673-eleceed 2
 
 grabber/tcb:
 	go run . https://lhtranslation.net/manga/gaikotsu-kishi-sama-tadaima-isekai-e-o-dekake-chuu/ 71

--- a/makefile
+++ b/makefile
@@ -50,6 +50,11 @@ grabber/qimanga:
 grabber/tcb:
 	go run . https://lhtranslation.net/manga/gaikotsu-kishi-sama-tadaima-isekai-e-o-dekake-chuu/ 71
 
+# sites needing a real browser: not part of the `grabber` target since they
+# open a Chrome window and may require solving an interactive challenge
+grabber/browser:
+	go run . --browser-visible https://www.toongod.org/webtoon/solo-leveling/ 200
+
 grabber/html:
 	go run . https://tcbonepiecechapters.com/mangas/5/one-piece 1100
 	go run . https://asurascans.com/comics/absolute-regression-f886a8af 1

--- a/makefile
+++ b/makefile
@@ -33,28 +33,20 @@ else
 	go test -v ./...
 endif
 
-grabber: grabber/inmanga grabber/mangadex grabber/tcb grabber/html
+grabber: grabber/inmanga grabber/mangadex grabber/mangabats grabber/tcb grabber/html
 
 grabber/inmanga:
-	go run . https://inmanga.com/ver/manga/One-Piece/dfc7ecb5-e9b3-4aa5-a61b-a498993cd935 1
+	go run . https://inmanga.com/ver/manga/One-Piece/dfc7ecb5-e9b3-4aa5-a61b-a498993cd935 1187
 
 grabber/mangadex:
-	go run . https://mangadex.org/title/a1c7c817-4e59-43b7-9365-09675a149a6f/one-piece --language es 1-4 --bundle
+	go run . https://mangadex.org/title/a1c7c817-4e59-43b7-9365-09675a149a6f/one-piece --language es 373 --bundle
+
+grabber/mangabats:
+	go run . https://www.mangabats.com/manga/after-the-possessor-left 1
 
 grabber/tcb:
-	go run . https://www.tcbscans.net/manga/one-piece/ 5
-	go run . https://ww1.tcbscans.org/manga/ao-ashi/ 203
-	go run . https://lscomic.com/manga/peerless-dad/ 285
+	go run . https://lhtranslation.net/manga/gaikotsu-kishi-sama-tadaima-isekai-e-o-dekake-chuu/ 71
 
 grabber/html:
-	go run . https://tcbscans.com/mangas/5/one-piece 1100
-	go run . https://mangakakalot.com/manga/vd921334 7
-	go run . https://ww7.mangakakalot.tv/chapter/manga-hj984766/chapter-86 86
-	go run . https://ww5.manganelo.tv/manga/manga-aa951409 3
-	go run . https://asuratoon.com/manga/0435219386-return-of-the-sss-class-ranker/ 85
-	go run . https://mangajar.pro/manga/haite-kudasai-takamine-san 43
-	go run . https://chapmanganato.com/manga-aa951409 50
-	go run . https://readmangabat.com/read-ov357862 23
-	go run . https://h.mangabat.com/read-tc397521 5
-	go run . https://mangapanda.in/manga/dragon-ball-super-color-%E2%AD%90%E2%AD%90%E2%AD%90%E2%AD%90%E2%AD%90 90
-	go run . https://mangamonks.com/manga/mashle 155
+	go run . https://tcbonepiecechapters.com/mangas/5/one-piece 1100
+	go run . https://asurascans.com/comics/absolute-regression-f886a8af 1

--- a/tools/probe/main.go
+++ b/tools/probe/main.go
@@ -1,0 +1,61 @@
+// Probe is a throwaway dev tool to inspect what the browser package sees on a
+// given URL. Not part of the app.
+package main
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/PuerkitoBio/goquery"
+	"github.com/elboletaire/manga-downloader/browser"
+)
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: probe <url> [waitSelector] [querySelector...]")
+		os.Exit(1)
+	}
+	url := os.Args[1]
+	wait := ""
+	if len(os.Args) > 2 {
+		wait = os.Args[2]
+	}
+
+	if os.Getenv("PROBE_VISIBLE") == "1" {
+		browser.SetVisible(true)
+	}
+
+	start := time.Now()
+	html, err := browser.GetHTML(url, wait, 45*time.Second)
+	fmt.Printf("elapsed: %s\n", time.Since(start))
+	if err != nil {
+		fmt.Println("ERROR:", err)
+		browser.Close()
+		os.Exit(1)
+	}
+
+	doc, _ := goquery.NewDocumentFromReader(strings.NewReader(html))
+	fmt.Println("page title:", strings.TrimSpace(doc.Find("title").Text()))
+	fmt.Println("html size:", len(html))
+
+	for _, sel := range os.Args[3:] {
+		matches := doc.Find(sel)
+		fmt.Printf("selector %q → %d matches\n", sel, matches.Length())
+		matches.Slice(0, min(3, matches.Length())).Each(func(i int, s *goquery.Selection) {
+			h, _ := goquery.OuterHtml(s)
+			if len(h) > 300 {
+				h = h[:300] + "..."
+			}
+			fmt.Printf("  [%d] %s\n", i, strings.TrimSpace(h))
+		})
+	}
+
+	if f := os.Getenv("PROBE_DUMP"); f != "" {
+		os.WriteFile(f, []byte(html), 0644)
+		fmt.Println("dumped to", f)
+	}
+
+	browser.Close()
+}

--- a/tools/probe/main.go
+++ b/tools/probe/main.go
@@ -28,6 +28,19 @@ func main() {
 	if os.Getenv("PROBE_VISIBLE") == "1" {
 		browser.SetVisible(true)
 	}
+	if s := os.Getenv("PROBE_SLEEP"); s != "" {
+		if d, err := time.ParseDuration(s); err == nil {
+			browser.SetSettle(d)
+		}
+	}
+	if os.Getenv("PROBE_NETLOG") == "1" {
+		browser.NetLog = func(u string, status int, mime string) {
+			if strings.Contains(mime, "image") || strings.Contains(mime, "css") || strings.Contains(mime, "font") || strings.Contains(mime, "javascript") {
+				return
+			}
+			fmt.Printf("NET %d %s %s\n", status, mime, u)
+		}
+	}
 
 	start := time.Now()
 	html, err := browser.GetHTML(url, wait, 45*time.Second)

--- a/tools/probe/main.go
+++ b/tools/probe/main.go
@@ -4,12 +4,14 @@ package main
 
 import (
 	"fmt"
+	"io"
 	"os"
 	"strings"
 	"time"
 
 	"github.com/PuerkitoBio/goquery"
 	"github.com/elboletaire/manga-downloader/browser"
+	"github.com/elboletaire/manga-downloader/http"
 )
 
 func main() {
@@ -55,6 +57,29 @@ func main() {
 	if f := os.Getenv("PROBE_DUMP"); f != "" {
 		os.WriteFile(f, []byte(html), 0644)
 		fmt.Println("dumped to", f)
+	}
+
+	// PROBE_FETCH_SEL: grab the first image matching the selector and try to
+	// download it via plain HTTP with the harvested browser session
+	if sel := os.Getenv("PROBE_FETCH_SEL"); sel != "" {
+		img := doc.Find(sel).First()
+		src := img.AttrOr("src", img.AttrOr("data-src", ""))
+		src = strings.TrimSpace(src)
+		fmt.Printf("fetching %q via plain HTTP...\n", src)
+		if src != "" {
+			body, err := http.Get(http.RequestParams{URL: src, Referer: url})
+			if err != nil {
+				fmt.Println("  FETCH ERROR:", err)
+			} else {
+				data, _ := io.ReadAll(body)
+				body.Close()
+				head := data
+				if len(head) > 16 {
+					head = head[:16]
+				}
+				fmt.Printf("  got %d bytes, magic: %q\n", len(data), head)
+			}
+		}
 	}
 
 	browser.Close()


### PR DESCRIPTION
This is Opus 4.8 speaking in behalf of elbolataire.

## Summary

This branch upgrades site support with a new browser-rendering layer and adds six sites, plus a CI fix so the toolchain matches `go.mod`. It's intended to ship as **v1.0.0**.

## Browser rendering layer

A new `browser` package drives a locally-installed Chromium browser (Chrome / Chromium / Brave / Edge, auto-discovered via chromedp) for sites plain HTTP can't scrape — JS-rendered pages, TLS-fingerprint blocks and Cloudflare challenges. One shared browser process is started lazily and reused. After each render it harvests the session cookies + real User-Agent into the `http` package, so images still download over the fast plain-HTTP path, reusing the browser's Cloudflare clearance.

- `grabber/plainhtmlbrowser.go` (`PlainHTMLBrowser`) is the browser-rendered twin of `PlainHTML`: same selector-driven parsing, but matched **by domain** and fetched through Chrome.
- `--browser-visible` runs the browser headed. CDP automation is detectable, so managed Cloudflare challenges time out headless but resolve in a couple of seconds in a visible window (where an interactive challenge can also be solved by hand). The wait-selector timeout error points the user at the flag.

## Newly supported sites

| Site | Issue | How |
| --- | --- | --- |
| zonatmo.org (TuMangaOnline) | #62 | plain HTTP (successor domain dropped the TLS block) |
| mangafire.to | #49 | open JSON API, no browser needed |
| toongod.org | #56 | browser (Cloudflare) |
| dragontea.ink | #31 | browser (Cloudflare) |
| kappabeast.com | #48 | browser (Cloudflare) |
| sushiscan.net | #70 | browser (Cloudflare) |

colamanga (#30) is left unsupported: it now gates the reader behind their app on top of client-side image encryption — not feasible.

## CI / release

- `go.mod` was bumped to `go 1.26` (required by chromedp). The `test` and `release` workflows still pinned Go 1.19, which cannot build the module — both are now on 1.26, with `checkout`, `setup-go` and `go-release-action` bumped to current majors.

## Docs & tests

- README: single alphabetical supported-sites list, marking browser-only sites with an asterisk + a note; documents `--browser-visible`; refreshed installation (per-OS, current macOS Gatekeeper steps).
- CLAUDE.md: documents the browser package and the site-investigation lessons.
- Unit tests for the parsing helpers (chapter-number parsing, image-URL extraction, browser-selector matching, mangafire hid); smoke-test makefile targets for the new sites.
- `tools/probe`: a dev tool that renders a URL in Chrome and tests selectors.

Closes #31, #48, #49, #56, #62, #70
