### PR TITLE
ci: add weekly live-site smoke tests

### DIFF
--- a/.github/workflows/smoke.yaml
+++ b/.github/workflows/smoke.yaml
@@ -1,0 +1,45 @@
+name: Site smoke tests
+
+# Weekly run of the live-site smoke targets to detect layout/API changes on
+# supported sites. Browser-based sites (make grabber/browser) are excluded:
+# they need a visible Chrome and often an interactive Cloudflare challenge,
+# which cannot work on a headless datacenter runner.
+on:
+  schedule:
+    - cron: "17 6 * * 1"
+  workflow_dispatch:
+
+jobs:
+  grabber:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        target:
+          - inmanga
+          - mangadex
+          - mangabats
+          - mangafire
+          - qimanga
+          - tcb
+          - tcbscans
+          - asura
+          - zonatmo
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.26"
+
+      - name: Download chapters
+        run: make grabber/${{ matrix.target }}
+
+      # The downloader exits 0 even when chapters or pages fail to download,
+      # so check the archives actually contain images.
+      - name: Verify CBZ contents
+        run: |
+          ls -la *.cbz
+          go run ./tools/verify-cbz *.cbz

--- a/makefile
+++ b/makefile
@@ -73,7 +73,13 @@ grabber/sushiscan:
 grabber/mangakakalot:
 	go run . --browser-visible https://www.mangakakalot.gg/manga/akuyaku-reijou-kara-no-kareinaru-tenshin-aisare-heroine-anthology-comic 1
 
-grabber/html:
+grabber/html: grabber/tcbscans grabber/asura grabber/zonatmo
+
+grabber/tcbscans:
 	go run . https://tcbonepiecechapters.com/mangas/5/one-piece 1100
+
+grabber/asura:
 	go run . https://asurascans.com/comics/absolute-regression-f886a8af 1
+
+grabber/zonatmo:
 	go run . https://zonatmo.org/library/manga/31322/one-piece 1188

--- a/tools/verify-cbz/main.go
+++ b/tools/verify-cbz/main.go
@@ -1,0 +1,102 @@
+// verify-cbz checks that the given .cbz files are real chapter archives:
+// they must exist, contain at least MinPages entries, and every entry must
+// be a non-empty image (JPG/PNG/GIF/WebP, checked by magic bytes).
+//
+// The downloader exits 0 even when individual chapters or pages fail, so
+// smoke tests must inspect the produced archives to detect broken sites.
+//
+// Usage: go run ./tools/verify-cbz file1.cbz [file2.cbz ...]
+package main
+
+import (
+	"archive/zip"
+	"bytes"
+	"fmt"
+	"io"
+	"os"
+)
+
+// MinPages is the minimum number of image entries a chapter archive must
+// contain to be considered valid.
+const MinPages = 3
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Fprintln(os.Stderr, "usage: verify-cbz file1.cbz [file2.cbz ...]")
+		os.Exit(2)
+	}
+
+	failed := false
+	for _, path := range os.Args[1:] {
+		if err := verify(path); err != nil {
+			fmt.Fprintf(os.Stderr, "FAIL %s: %v\n", path, err)
+			failed = true
+			continue
+		}
+		fmt.Printf("OK   %s\n", path)
+	}
+
+	if failed {
+		os.Exit(1)
+	}
+}
+
+func verify(path string) error {
+	r, err := zip.OpenReader(path)
+	if err != nil {
+		return fmt.Errorf("cannot open as zip: %w", err)
+	}
+	defer r.Close()
+
+	images := 0
+	for _, f := range r.File {
+		if f.FileInfo().IsDir() {
+			continue
+		}
+		if f.UncompressedSize64 == 0 {
+			return fmt.Errorf("entry %q is empty", f.Name)
+		}
+		ok, err := isImage(f)
+		if err != nil {
+			return fmt.Errorf("entry %q: %w", f.Name, err)
+		}
+		if !ok {
+			return fmt.Errorf("entry %q is not a recognised image", f.Name)
+		}
+		images++
+	}
+
+	if images < MinPages {
+		return fmt.Errorf("only %d image entries, expected at least %d", images, MinPages)
+	}
+
+	return nil
+}
+
+func isImage(f *zip.File) (bool, error) {
+	rc, err := f.Open()
+	if err != nil {
+		return false, err
+	}
+	defer rc.Close()
+
+	head := make([]byte, 12)
+	n, err := io.ReadFull(rc, head)
+	if err != nil && err != io.ErrUnexpectedEOF {
+		return false, err
+	}
+	head = head[:n]
+
+	switch {
+	case bytes.HasPrefix(head, []byte{0xff, 0xd8, 0xff}): // JPEG
+		return true, nil
+	case bytes.HasPrefix(head, []byte{0x89, 'P', 'N', 'G'}): // PNG
+		return true, nil
+	case bytes.HasPrefix(head, []byte("GIF8")): // GIF
+		return true, nil
+	case bytes.HasPrefix(head, []byte("RIFF")) && len(head) >= 12 && bytes.Equal(head[8:12], []byte("WEBP")): // WebP
+		return true, nil
+	}
+
+	return false, nil
+}


### PR DESCRIPTION
This is Fable 5 speaking in behalf of elbolataire.

## What

Adds a scheduled GitHub Actions workflow (`smoke.yaml`, Mondays 06:17 UTC + manual `workflow_dispatch`) that runs the plain-HTTP grabber smoke targets against the live sites, one matrix job per site with `fail-fast: false` — so when a site changes its layout, the failing job names it directly (e.g. `grabber (asura)`).

## Why the extra verifier

The downloader exits 0 even when individual chapters or pages fail to download (`cmd/root.go` prints the error and continues), so a broken reader selector would pass a naive CI run. Each matrix job therefore runs the new `tools/verify-cbz` checker on the produced archives: they must open as zip, contain at least 3 entries, and every entry must be a non-empty image with real JPG/PNG/GIF/WebP magic bytes.

## Other changes

- `grabber/html` makefile target split into `grabber/tcbscans`, `grabber/asura` and `grabber/zonatmo` so the matrix can run/fail them independently (`make grabber/html` still runs all three).
- Browser-based sites (`grabber/browser`) are deliberately excluded: they need a visible Chrome and often an interactive Cloudflare challenge, which can't work on a headless datacenter runner.

## Notes

- Verified locally end to end: `make grabber/mangabats` produced a 10.6M CBZ and `verify-cbz` validated it; the verifier was also tested against crafted bad archives (text entries, empty entries, too-few pages, HTML saved as `.cbz`) and caught all of them.
- Expect possible false failures on the first scheduled run: GitHub runners use datacenter IPs and Cloudflare-fronted sites (asura/zonatmo are the likely candidates) may challenge them even though they work from residential IPs. Worth triggering once manually from the Actions tab to see which sites are viable.
- GitHub disables scheduled workflows after 60 days without repo activity (one click re-enables).