### PR TITLE
fix(mangadex): skip external chapters that report a page count

### DIFF
--- a/grabber/mangadex.go
+++ b/grabber/mangadex.go
@@ -119,9 +119,11 @@ func (m Mangadex) FetchChapters() (chapters Filterables, errs []error) {
 		}
 
 		for _, c := range body.Data {
-			// skip pageless chapters (i.e. those hosted outside mangadex, on
-			// official publisher sites): there's nothing to download from them
-			if c.Attributes.Pages == 0 {
+			// skip chapters hosted outside mangadex (official publisher
+			// sites): there's nothing to download from them. They usually
+			// report 0 pages, but some stubs still claim a page count, so
+			// check the external url too.
+			if c.Attributes.Pages == 0 || c.Attributes.ExternalUrl != "" {
 				continue
 			}
 			num, _ := strconv.ParseFloat(c.Attributes.Chapter, 64)
@@ -219,6 +221,7 @@ type mangadexFeed struct {
 			Title              string
 			TranslatedLanguage string
 			Pages              int64
+			ExternalUrl        string
 		}
 	}
 }

--- a/makefile
+++ b/makefile
@@ -38,8 +38,10 @@ grabber: grabber/inmanga grabber/mangadex grabber/mangabats grabber/mangafire gr
 grabber/inmanga:
 	go run . https://inmanga.com/ver/manga/One-Piece/dfc7ecb5-e9b3-4aa5-a61b-a498993cd935 1187
 
+# note: use a language without an official publisher (i.e. not es/en/fr...):
+# licensed translations get replaced by pageless mangaplus stubs on mangadex
 grabber/mangadex:
-	go run . https://mangadex.org/title/a1c7c817-4e59-43b7-9365-09675a149a6f/one-piece --language es 373 --bundle
+	go run . https://mangadex.org/title/a1c7c817-4e59-43b7-9365-09675a149a6f/one-piece --language ca 1187 --bundle
 
 grabber/mangabats:
 	go run . https://www.mangabats.com/manga/after-the-possessor-left 1


### PR DESCRIPTION
This is Fable 5 speaking in behalf of elbolataire.

First catch of the new smoke tests! The `grabber (mangadex)` job failed with `only 1 image entries, expected at least 3` — and it turned out to be a real grabber bug, not a flaky test.

## Root cause

MangaDex replaces licensed translations with stubs pointing to the publisher's site. The feed filter in `grabber/mangadex.go` skipped those only when `pages == 0`, but some stubs claim a page count: the Spanish One Piece chapter 373 stub reports `pages: 1` with `externalUrl: mangaplus.shueisha.co.jp`, so it slipped through and produced a junk single-image bundle. Any user downloading ranges that include such stubs hits the same thing.

## Fix

- Skip any feed chapter with a non-empty `externalUrl`, regardless of its reported page count.
- Repoint the smoke target: the **entire** Spanish One Piece feed on MangaDex is now MangaPlus stubs (18 chapters, 0 real ones), so the old target can never pass again. The new target uses the Catalan translation (`--language ca 1187`) — 397 real chapters, and with no official Catalan publisher it won't get license-purged.

## Verified

- `make grabber/mangadex` downloads a real 26-page bundle (28.9M) and `verify-cbz` passes.
- The old Spanish command now exits 1 with "No chapters found" instead of writing a junk archive.