### PR TITLE
ci(docker): publish multi-arch images (amd64 + arm64)

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -33,6 +33,12 @@ jobs:
             type=ref,event=pr
             type=semver,pattern={{version}}
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
@@ -44,6 +50,7 @@ jobs:
         with:
           context: .
           file: docker/Dockerfile
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,10 +1,13 @@
 # Build from a golang based image
-FROM golang:latest as builder
+FROM --platform=$BUILDPLATFORM golang:latest AS builder
 
 LABEL maintainer="Òscar Casajuana <elboletaire@underave.net>"
 
 ARG CI_COMMIT_REF_NAME
 ENV CI_COMMIT_REF_NAME ${CI_COMMIT_REF_NAME:-latest}
+
+ARG TARGETOS
+ARG TARGETARCH
 
 WORKDIR /app
 
@@ -12,7 +15,7 @@ COPY go.mod go.sum ./
 RUN go mod download
 COPY . .
 
-RUN make build/unix
+RUN GOOS=$TARGETOS GOARCH=$TARGETARCH make build/unix
 
 # Start a new stage from scratch
 FROM alpine:latest


### PR DESCRIPTION
This is Fable 5 speaking in behalf of elboletaire.

Closes #35.

## What

- `docker/Dockerfile`: the builder stage is now pinned to `--platform=$BUILDPLATFORM` and cross-compiles with `GOOS=$TARGETOS GOARCH=$TARGETARCH`, so the Go build runs at native speed instead of under QEMU emulation (CGO is already disabled, making cross-compilation free). Also fixed the `as builder` → `AS builder` casing warning.
- `.github/workflows/docker.yaml`: added `docker/setup-qemu-action@v3` and `docker/setup-buildx-action@v3`, and set `platforms: linux/amd64,linux/arm64` on the build-push step.

## Verification

- `docker buildx build --platform linux/arm64` was run locally and completed successfully.
- The binary inside the resulting image was confirmed to be a genuine aarch64 ELF (`e_machine = 0xb7`), not just a successful build exit code.
- The workflow YAML was validated to parse.

Note: QEMU is only needed for the runtime stage's `RUN` steps; compilation stays native thanks to `$BUILDPLATFORM`.