### PR TITLE
feat(downloader): retry failed page downloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,7 @@ variables are `{{.Series}}`, `{{.Number}}`, `{{.Title}}` and `{{.Version}}`
 | `--concurrency`       | `-c`  | Concurrent chapter downloads (max 5)                     | 5                  |
 | `--concurrency-pages` | `-C`  | Concurrent page downloads per chapter (max 10)           | 10                 |
 | `--browser-visible`   |       | Open the browser from the start (opens automatically on a challenge anyway) | off        |
+| `--retry`             | `-r`  | Retries for failed page downloads (max 3, 0 disables retrying)  | 1                  |
 
 Run the `help` command to see them all from your terminal:
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -346,6 +346,7 @@ func init() {
 	rootCmd.Flags().StringVarP(&settings.Language, "language", "l", "", "only download the specified language")
 	rootCmd.Flags().StringVarP(&settings.FilenameTemplate, "filename-template", "t", packer.FilenameTemplateDefault, "template for the resulting filename")
 	rootCmd.Flags().BoolVar(&settings.BrowserVisible, "browser-visible", false, "open the browser window from the start (it opens automatically anyway when a headless attempt hits a challenge)")
+	rootCmd.Flags().Uint8VarP(&settings.Retry, "retry", "r", 1, "number of retries for failed page downloads, hard-limited to 3 (0 disables retrying)")
 	// set as persistent, so version command does not complain about the -o flag set via docker
 	rootCmd.PersistentFlags().StringVarP(&settings.OutputDir, "output-dir", "o", "./", "output directory for the downloaded files")
 }

--- a/downloader/fetch.go
+++ b/downloader/fetch.go
@@ -5,10 +5,15 @@ import (
 	"io"
 	"sort"
 	"sync"
+	"time"
 
 	"github.com/elboletaire/manga-downloader/grabber"
 	"github.com/elboletaire/manga-downloader/http"
 )
+
+// retryDelay is the base delay between retry attempts (multiplied by the
+// attempt number). It's a package-level var so tests can shrink it.
+var retryDelay = time.Second
 
 // File represents a downloaded file
 type File struct {
@@ -36,7 +41,7 @@ func FetchChapter(site grabber.Site, chapter *grabber.Chapter, onprogress Progre
 			file, err := FetchFile(http.RequestParams{
 				URL:     page.URL,
 				Referer: site.BaseUrl(),
-			}, uint(page.Number))
+			}, uint(page.Number), site.GetRetries())
 
 			if err != nil {
 				select {
@@ -75,25 +80,37 @@ func FetchChapter(site grabber.Site, chapter *grabber.Chapter, onprogress Progre
 	return
 }
 
-// FetchFile gets an online file returning a new *File with its contents
-func FetchFile(params http.RequestParams, page uint) (file *File, err error) {
+// FetchFile gets an online file returning a new *File with its contents.
+// On failure (either the GET itself or a mid-body read) it retries up to
+// `retries` additional times, with a short growing delay between attempts.
+func FetchFile(params http.RequestParams, page uint, retries uint8) (file *File, err error) {
+	for attempt := uint8(0); ; attempt++ {
+		var data []byte
+		data, err = fetchFileOnce(params)
+		if err == nil {
+			file = &File{
+				Data: data,
+				Page: page,
+			}
+			return
+		}
+
+		if attempt >= retries {
+			return
+		}
+
+		time.Sleep(retryDelay * time.Duration(attempt+1))
+	}
+}
+
+// fetchFileOnce performs a single GET + body read attempt
+func fetchFileOnce(params http.RequestParams) (data []byte, err error) {
 	body, err := http.Get(params)
 	if err != nil {
-		// TODO: should retry at least once (configurable)
 		return
 	}
-
 	defer body.Close()
 
-	data, err := io.ReadAll(body)
-	if err != nil {
-		return
-	}
-
-	file = &File{
-		Data: data,
-		Page: page,
-	}
-
+	data, err = io.ReadAll(body)
 	return
 }

--- a/downloader/fetch_test.go
+++ b/downloader/fetch_test.go
@@ -1,0 +1,124 @@
+package downloader
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	mangahttp "github.com/elboletaire/manga-downloader/http"
+)
+
+// withFastRetryDelay shrinks the package-level retry delay for the duration
+// of a test, restoring the original value afterwards.
+func withFastRetryDelay(t *testing.T) {
+	t.Helper()
+	original := retryDelay
+	retryDelay = time.Millisecond
+	t.Cleanup(func() {
+		retryDelay = original
+	})
+}
+
+func TestFetchFile_RetriesOnGetFailure(t *testing.T) {
+	withFastRetryDelay(t)
+
+	var requests int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if atomic.AddInt32(&requests, 1) == 1 {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("hello"))
+	}))
+	defer server.Close()
+
+	file, err := FetchFile(mangahttp.RequestParams{URL: server.URL}, 1, 1)
+	if err != nil {
+		t.Fatalf("expected no error after retry, got: %v", err)
+	}
+	if string(file.Data) != "hello" {
+		t.Errorf("expected file data %q, got %q", "hello", file.Data)
+	}
+	if got := atomic.LoadInt32(&requests); got != 2 {
+		t.Errorf("expected 2 requests, got %d", got)
+	}
+}
+
+func TestFetchFile_RetriesOnMidBodyReadFailure(t *testing.T) {
+	withFastRetryDelay(t)
+
+	var requests int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if atomic.AddInt32(&requests, 1) == 1 {
+			// promise more bytes than we actually send, then close the
+			// connection mid-body to simulate a "page cut at some point"
+			hj, ok := w.(http.Hijacker)
+			if !ok {
+				t.Fatal("response writer does not support hijacking")
+			}
+			conn, bufrw, err := hj.Hijack()
+			if err != nil {
+				t.Fatalf("hijack failed: %v", err)
+			}
+			defer conn.Close()
+			bufrw.WriteString("HTTP/1.1 200 OK\r\nContent-Length: 10\r\n\r\nabc")
+			bufrw.Flush()
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("full-body"))
+	}))
+	defer server.Close()
+
+	file, err := FetchFile(mangahttp.RequestParams{URL: server.URL}, 1, 1)
+	if err != nil {
+		t.Fatalf("expected no error after retry, got: %v", err)
+	}
+	if string(file.Data) != "full-body" {
+		t.Errorf("expected file data %q, got %q", "full-body", file.Data)
+	}
+	if got := atomic.LoadInt32(&requests); got != 2 {
+		t.Errorf("expected 2 requests, got %d", got)
+	}
+}
+
+func TestFetchFile_ExhaustsRetries(t *testing.T) {
+	withFastRetryDelay(t)
+
+	var requests int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&requests, 1)
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	_, err := FetchFile(mangahttp.RequestParams{URL: server.URL}, 1, 1)
+	if err == nil {
+		t.Fatal("expected an error after exhausting retries")
+	}
+	if got := atomic.LoadInt32(&requests); got != 2 {
+		t.Errorf("expected 2 requests (1 initial + 1 retry), got %d", got)
+	}
+}
+
+func TestFetchFile_NoRetries(t *testing.T) {
+	withFastRetryDelay(t)
+
+	var requests int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&requests, 1)
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	_, err := FetchFile(mangahttp.RequestParams{URL: server.URL}, 1, 0)
+	if err == nil {
+		t.Fatal("expected an error on first failure")
+	}
+	if got := atomic.LoadInt32(&requests); got != 1 {
+		t.Errorf("expected exactly 1 request (no retries), got %d", got)
+	}
+}

--- a/grabber/site.go
+++ b/grabber/site.go
@@ -36,6 +36,8 @@ type Settings struct {
 	// BrowserVisible shows the browser window for sites that need one, so
 	// interactive challenges (e.g. cloudflare) can be solved manually
 	BrowserVisible bool
+	// Retry is the number of retries for failed page downloads
+	Retry uint8
 }
 
 // MaxConcurrency is the max concurrency for a site
@@ -66,6 +68,8 @@ type Site interface {
 	GetMaxConcurrency() MaxConcurrency
 	// GetPreferredLanguage returns the preferred language for the site
 	GetPreferredLanguage() string
+	// GetRetries returns the number of retries for failed page downloads
+	GetRetries() uint8
 }
 
 // IdentifySite returns the site passing the Test() for the specified url
@@ -123,6 +127,11 @@ func (g Grabber) GetFilenameTemplate() string {
 	return g.Settings.FilenameTemplate
 }
 
+// GetRetries returns the number of retries for failed page downloads
+func (g Grabber) GetRetries() uint8 {
+	return g.Settings.Retry
+}
+
 // InitFlags initializes the command flags
 func (g *Grabber) InitFlags(cmd *cobra.Command) {
 	g.SetMaxConcurrency(MaxConcurrency{
@@ -131,6 +140,7 @@ func (g *Grabber) InitFlags(cmd *cobra.Command) {
 	})
 	g.Settings.Language = cmd.Flag("language").Value.String()
 	g.Settings.FilenameTemplate = cmd.Flag("filename-template").Value.String()
+	g.Settings.Retry = maxUint8Flag(cmd.Flag("retry"), 3)
 }
 
 // NewSite returns a new site based on the passed url


### PR DESCRIPTION
This is Fable 5 speaking in behalf of elboletaire.

Closes #18.

## What

Page fetches can fail transiently (network error, non-200 status, or a body cut mid-read), leaving a CBZ with a missing or truncated page. `FetchFile` now retries the whole GET + body-read cycle:

- Covers **both** failure modes — a failed request *and* a response body that dies mid-read (the "page cut at some point" case from the issue), which previously wasn't retried at all.
- New `--retry`/`-r` flag: number of retries for failed page downloads, default `1`, hard-limited to `3` (same `maxUint8Flag` pattern as the concurrency flags) to avoid tripping site bans; `0` disables retrying.
- A short growing delay between attempts.
- Scope is page image downloads only — HTML/chapter-list fetches are untouched.

## Verification

- 4 new `httptest`-based tests in `downloader/fetch_test.go`: retry-then-succeed on a 500, retry-then-succeed on a mid-body cut (hijacked connection with an undelivered `Content-Length`), retries exhausted → error, and `retries=0` → exactly one request.
- `go build`, `go vet`, `go test ./...` all pass.