### PR TITLE
feat(packer): group bundled chapters into per-chapter folders

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,9 @@ manga-downloader https://inmanga.com/ver/manga/One-Piece/dfc7ecb5-e9b3-4aa5-a61b
 # downloads One Piece chapters 1 to 8 into a single file
 ~~~
 
+Inside the bundle, each chapter gets its own folder (e.g. `Chapter 0001/`,
+`Chapter 0002/`) so chapter boundaries and page numbering are preserved.
+
 ![bundle img]
 
 ### Custom file names

--- a/packer/cbz.go
+++ b/packer/cbz.go
@@ -3,14 +3,19 @@ package packer
 import (
 	"archive/zip"
 	"errors"
-	"fmt"
 	"os"
-
-	"github.com/elboletaire/manga-downloader/downloader"
 )
 
-// ArchiveCBZ archives the given files into a CBZ file
-func ArchiveCBZ(filename string, files []*downloader.File, progress func(page, progress int)) error {
+// File represents a named entry to be written into a CBZ archive
+type File struct {
+	// Name is the zip entry name (may include a directory prefix, e.g. "Chapter 0001/000.jpg")
+	Name string
+	// Data is the raw file contents
+	Data []byte
+}
+
+// ArchiveCBZ archives the given named files into a CBZ file
+func ArchiveCBZ(filename string, files []File, progress func(page, progress int)) error {
 	if len(files) == 0 {
 		return errors.New("no files to pack")
 	}
@@ -21,8 +26,8 @@ func ArchiveCBZ(filename string, files []*downloader.File, progress func(page, p
 	defer buff.Close()
 	w := zip.NewWriter(buff)
 
-	for i, file := range files {
-		f, err := w.Create(fmt.Sprintf("%03d.jpg", i))
+	for _, file := range files {
+		f, err := w.Create(file.Name)
 		if err != nil {
 			return err
 		}

--- a/packer/cbz_test.go
+++ b/packer/cbz_test.go
@@ -1,0 +1,155 @@
+package packer
+
+import (
+	"archive/zip"
+	"path/filepath"
+	"testing"
+
+	"github.com/elboletaire/manga-downloader/downloader"
+	"github.com/elboletaire/manga-downloader/grabber"
+	"github.com/spf13/cobra"
+)
+
+// entryNames opens the zip at path and returns its entry names, in order.
+func entryNames(t *testing.T, path string) []string {
+	t.Helper()
+
+	r, err := zip.OpenReader(path)
+	if err != nil {
+		t.Fatalf("opening archive: %v", err)
+	}
+	defer r.Close()
+
+	names := make([]string, len(r.File))
+	for i, f := range r.File {
+		names[i] = f.Name
+	}
+	return names
+}
+
+func TestArchiveCBZNoFiles(t *testing.T) {
+	err := ArchiveCBZ(filepath.Join(t.TempDir(), "empty.cbz"), []File{}, func(page, progress int) {})
+	if err == nil {
+		t.Fatal("expected an error when archiving zero files, got nil")
+	}
+}
+
+func TestArchiveCBZEntryNames(t *testing.T) {
+	// Simulate a bundle: two chapters, each with its own folder and page
+	// numbering restarting at 000, per issue #47.
+	files := []File{
+		{Name: "Chapter 0001/000.jpg", Data: []byte("ch1-p0")},
+		{Name: "Chapter 0001/001.jpg", Data: []byte("ch1-p1")},
+		{Name: "Chapter 0002/000.jpg", Data: []byte("ch2-p0")},
+	}
+
+	path := filepath.Join(t.TempDir(), "bundle.cbz")
+	if err := ArchiveCBZ(path, files, func(page, progress int) {}); err != nil {
+		t.Fatalf("ArchiveCBZ: %v", err)
+	}
+
+	names := entryNames(t, path)
+	want := []string{"Chapter 0001/000.jpg", "Chapter 0001/001.jpg", "Chapter 0002/000.jpg"}
+	if len(names) != len(want) {
+		t.Fatalf("got %d entries, want %d: %v", len(names), len(want), names)
+	}
+	for i, n := range names {
+		if n != want[i] {
+			t.Errorf("entry %d = %q, want %q", i, n, want[i])
+		}
+	}
+
+	// Both chapters must independently contain a 000.jpg (no global renumbering).
+	seen000 := 0
+	for _, n := range names {
+		if filepath.Base(n) == "000.jpg" {
+			seen000++
+		}
+	}
+	if seen000 != 2 {
+		t.Errorf("expected 2 entries named 000.jpg (one per chapter folder), got %d", seen000)
+	}
+}
+
+func TestPaddedChapterNumber(t *testing.T) {
+	cases := []struct {
+		in   float64
+		want string
+	}{
+		{1, "0001"},
+		{10, "0010"},
+		{10.5, "0010.5"},
+		{186, "0186"},
+		{1186, "1186"},
+		{1186.5, "1186.5"},
+		{0, "0000"},
+	}
+
+	for _, c := range cases {
+		if got := paddedChapterNumber(c.in); got != c.want {
+			t.Errorf("paddedChapterNumber(%v) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}
+
+// fakeSite is a minimal grabber.Site implementation for testing PackBundle's
+// entry-naming behavior without hitting a real site.
+type fakeSite struct {
+	title    string
+	template string
+}
+
+func (f *fakeSite) InitFlags(cmd *cobra.Command)                  {}
+func (f *fakeSite) Test() (bool, error)                           { return true, nil }
+func (f *fakeSite) FetchChapters() (grabber.Filterables, []error) { return nil, nil }
+func (f *fakeSite) FetchChapter(grabber.Filterable) (*grabber.Chapter, error) {
+	return nil, nil
+}
+func (f *fakeSite) FetchTitle() (string, error) { return f.title, nil }
+func (f *fakeSite) BaseUrl() string             { return "https://example.com" }
+func (f *fakeSite) GetFilenameTemplate() string { return f.template }
+func (f *fakeSite) GetMaxConcurrency() grabber.MaxConcurrency {
+	return grabber.MaxConcurrency{Chapters: 1, Pages: 1}
+}
+func (f *fakeSite) GetPreferredLanguage() string { return "" }
+
+func TestPackBundleEntryNames(t *testing.T) {
+	site := &fakeSite{title: "Test Series", template: FilenameTemplateDefault}
+
+	chapters := []*DownloadedChapter{
+		{
+			Chapter: &grabber.Chapter{Number: 1},
+			Files: []*downloader.File{
+				{Data: []byte("ch1-p0")},
+				{Data: []byte("ch1-p1")},
+			},
+		},
+		{
+			Chapter: &grabber.Chapter{Number: 10.5},
+			Files: []*downloader.File{
+				{Data: []byte("ch10.5-p0")},
+			},
+		},
+	}
+
+	dir := t.TempDir()
+	filename, err := PackBundle(dir, site, chapters, "1-10.5", func(page, progress int) {})
+	if err != nil {
+		t.Fatalf("PackBundle: %v", err)
+	}
+
+	names := entryNames(t, filepath.Join(dir, filename))
+	want := []string{
+		"Chapter 0001/000.jpg",
+		"Chapter 0001/001.jpg",
+		"Chapter 0010.5/000.jpg",
+	}
+	if len(names) != len(want) {
+		t.Fatalf("got %d entries, want %d: %v", len(names), len(want), names)
+	}
+	for i, n := range names {
+		if n != want[i] {
+			t.Errorf("entry %d = %q, want %q", i, n, want[i])
+		}
+	}
+}

--- a/packer/filename.go
+++ b/packer/filename.go
@@ -3,6 +3,7 @@ package packer
 import (
 	"bytes"
 	"fmt"
+	"strconv"
 	"strings"
 	"text/template"
 
@@ -44,6 +45,27 @@ func NewChapterFileTemplateParts(title string, chapter *grabber.Chapter) Filenam
 		Number: strings.Replace(fmt.Sprintf("%.1f", chapter.GetNumber()), ".0", "", 1),
 		Title:  SanitizeFilename(chapter.GetTitle()),
 	}
+}
+
+// paddedChapterNumber formats a chapter number zero-padded to (at least) 4
+// integer digits so lexicographic ordering matches numeric ordering (e.g.
+// 1 -> "0001", 10.5 -> "0010.5", 1186 -> "1186"). Reuses the same
+// "%.1f, strip trailing .0" idea as NewChapterFileTemplateParts.
+func paddedChapterNumber(number float64) string {
+	numStr := strings.Replace(fmt.Sprintf("%.1f", number), ".0", "", 1)
+
+	intPart, fracPart := numStr, ""
+	if i := strings.IndexByte(numStr, '.'); i >= 0 {
+		intPart, fracPart = numStr[:i], numStr[i:]
+	}
+
+	intVal, err := strconv.Atoi(intPart)
+	if err != nil {
+		// Fall back to the unpadded representation if parsing ever fails.
+		return numStr
+	}
+
+	return fmt.Sprintf("%04d%s", intVal, fracPart)
 }
 
 // SanitizeFilename sanitizes a filename

--- a/packer/pack.go
+++ b/packer/pack.go
@@ -18,15 +18,23 @@ type DownloadedChapter struct {
 // PackSingle packs a single downloaded chapter
 func PackSingle(outputdir string, s grabber.Site, chapter *DownloadedChapter, progress func(page, progress int)) (string, error) {
 	title, _ := s.FetchTitle()
-	return pack(outputdir, s.GetFilenameTemplate(), title, NewChapterFileTemplateParts(title, chapter.Chapter), chapter.Files, progress)
+	return pack(outputdir, s.GetFilenameTemplate(), title, NewChapterFileTemplateParts(title, chapter.Chapter), namePages(chapter.Files), progress)
 }
 
-// PackBundle packs a bundle of downloaded chapters
+// PackBundle packs a bundle of downloaded chapters, grouping each chapter's
+// pages into its own folder inside the archive (Chapter 0001/000.jpg, ...)
+// so chapter boundaries survive bundling instead of a single flat renumbering.
 func PackBundle(outputdir string, s grabber.Site, chapters []*DownloadedChapter, rng string, progress func(page, progress int)) (string, error) {
 	title, _ := s.FetchTitle()
-	files := []*downloader.File{}
+	files := []File{}
 	for _, chapter := range chapters {
-		files = append(files, chapter.Files...)
+		folder := SanitizeFilename(fmt.Sprintf("Chapter %s", paddedChapterNumber(chapter.GetNumber())))
+		for _, page := range namePages(chapter.Files) {
+			files = append(files, File{
+				Name: fmt.Sprintf("%s/%s", folder, page.Name),
+				Data: page.Data,
+			})
+		}
 	}
 
 	return pack(outputdir, s.GetFilenameTemplate(), title, FilenameTemplateParts{
@@ -36,7 +44,20 @@ func PackBundle(outputdir string, s grabber.Site, chapters []*DownloadedChapter,
 	}, files, progress)
 }
 
-func pack(outputdir, template, title string, parts FilenameTemplateParts, files []*downloader.File, progress func(page, progress int)) (string, error) {
+// namePages names a chapter's pages sequentially (000.jpg, 001.jpg, ...),
+// restarting at 000 for each call.
+func namePages(pages []*downloader.File) []File {
+	named := make([]File, len(pages))
+	for i, page := range pages {
+		named[i] = File{
+			Name: fmt.Sprintf("%03d.jpg", i),
+			Data: page.Data,
+		}
+	}
+	return named
+}
+
+func pack(outputdir, template, title string, parts FilenameTemplateParts, files []File, progress func(page, progress int)) (string, error) {
 	parts.Version = 1
 
 	for {


### PR DESCRIPTION
This is Fable 5 speaking in behalf of elboletaire.

Closes #47.

## What

With `--bundle`, the resulting CBZ used to renumber all pages flatly (`000.jpg`, `001.jpg`, …), losing chapter boundaries. Bundled CBZs now contain one folder per chapter, with page numbering restarting inside each chapter:

```
Chapter 0001/000.jpg
Chapter 0001/001.jpg
Chapter 0002/000.jpg
...
```

- Chapter numbers are zero-padded so lexicographic order matches numeric order, and fractional chapters are handled (`10.5` → `Chapter 0010.5`).
- `ArchiveCBZ` now takes pre-named entries (a small `packer.File{Name, Data}` type) instead of naming pages itself; the `O_EXCL`/`os.IsExist` duplicate-filename versioning is preserved.
- Single-chapter CBZs (no `--bundle`) keep their current flat layout, unchanged.

## Verification

- New tests in `packer/cbz_test.go`: exact zip entry names (opened back with `archive/zip`), both chapters independently containing a `000.jpg`, a table test for the number padding, and an integration-style `PackBundle` test with a fake `grabber.Site` covering fractional chapter numbers end-to-end.
- `go build`, `go vet`, `go test ./...` all pass.

## Note for review

This PR touches `packer/pack.go`/`cbz.go`, as does #6's PR — whichever merges second will need a small rebase.