### PR TITLE
feat(grabber): add support for mangapill.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Supported sites
 - [mangafire.to](https://mangafire.to)
 - [mangakakalot.gg (MangaKakalot)](https://www.mangakakalot.gg) \*
 - [Mangadex](https://mangadex.org)
+- [mangapill.com](https://mangapill.com)
 - [qimanga.com](https://qimanga.com)
 - [sushiscan.net](https://sushiscan.net) \*
 - [tcbonepiecechapters.com (TCB Scans, former tcbscans.com)](https://tcbonepiecechapters.com)

--- a/grabber/plainhtml.go
+++ b/grabber/plainhtml.go
@@ -86,6 +86,14 @@ func (m *PlainHTML) Test() (bool, error) {
 			Link:         ".chapter-detail a.btn-primary",
 			Image:        "img.reader-image",
 		},
+		// mangapill.com: each chapter row is a plain <a> with the chapter
+		// number as its own text (no dedicated child selector), hence the
+		// empty Chapter/ChapterTitle (see FetchChapters)
+		{
+			Title: "h1",
+			Rows:  "#chapters [data-filter-list] a",
+			Image: "img.js-page",
+		},
 	}
 
 	// for the same priority reasons, we need to iterate over the selectors
@@ -145,7 +153,14 @@ func parseChapterNumber(text string) (float64, bool) {
 // FetchChapters returns a slice of chapters
 func (m PlainHTML) FetchChapters() (chapters Filterables, errs []error) {
 	m.rows.Each(func(i int, s *goquery.Selection) {
-		number, ok := parseChapterNumber(s.Find(m.site.Chapter).Text())
+		// an empty Chapter/ChapterTitle selector means the row itself carries
+		// the text (i.e. mangapill, where each chapter row is a plain <a>
+		// with no dedicated child element for the chapter number)
+		chapterText := s.Text()
+		if m.site.Chapter != "" {
+			chapterText = s.Find(m.site.Chapter).Text()
+		}
+		number, ok := parseChapterNumber(chapterText)
 		if !ok {
 			return
 		}
@@ -157,10 +172,14 @@ func (m PlainHTML) FetchChapters() (chapters Filterables, errs []error) {
 		if !strings.HasPrefix(u, "http") {
 			u = m.BaseUrl() + u
 		}
+		title := chapterText
+		if m.site.ChapterTitle != "" {
+			title = s.Find(m.site.ChapterTitle).Text()
+		}
 		chapter := &PlainHTMLChapter{
 			Chapter{
 				Number: number,
-				Title:  s.Find(m.site.ChapterTitle).Text(),
+				Title:  title,
 			},
 			u,
 		}

--- a/makefile
+++ b/makefile
@@ -75,7 +75,7 @@ grabber/sushiscan:
 grabber/mangakakalot:
 	go run . --browser-visible https://www.mangakakalot.gg/manga/akuyaku-reijou-kara-no-kareinaru-tenshin-aisare-heroine-anthology-comic 1
 
-grabber/html: grabber/tcbscans grabber/asura grabber/zonatmo
+grabber/html: grabber/tcbscans grabber/asura grabber/zonatmo grabber/mangapill
 
 grabber/tcbscans:
 	go run . https://tcbonepiecechapters.com/mangas/5/one-piece 1100
@@ -85,3 +85,6 @@ grabber/asura:
 
 grabber/zonatmo:
 	go run . https://zonatmo.org/library/manga/31322/one-piece 1188
+
+grabber/mangapill:
+	go run . https://mangapill.com/manga/2/one-piece 1188


### PR DESCRIPTION
This is Claude Fable 5 speaking in behalf of elboletaire.

Adds mangapill.com to the `PlainHTML` selector-driven grabber.

Chapter rows on mangapill are bare `<a>` tags with the chapter number as their own text (no separate selector for chapter number/title inside the row). To support this, `PlainHTML.FetchChapters` was generalized, in a backward-compatible way, to fall back to the row's own text/href when a selector entry has empty `Chapter`/`ChapterTitle` fields.

## Testing

Smoke-tested live against `https://mangapill.com/manga/2/one-piece`, downloading One Piece chapter 1188:
- CBZ produced with 15/15 pages
- All entries verified as real images (PNG/JPEG magic bytes checked)
- Full test suite (`go test ./...`) passes

## Note

This PR is part of a batch of new-site PRs, so small conflicts in `README.md`/`makefile` are expected when merging after its siblings.