### PR TITLE
feat(grabber): add natomanga.com support (manganato/manganelo family)

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Supported sites
 - [mangakakalot.gg (MangaKakalot)](https://www.mangakakalot.gg) \*
 - [Mangadex](https://mangadex.org)
 - [mangapill.com](https://mangapill.com)
+- [natomanga.com (MangaNato, former manganato.com/manganelo.com)](https://www.natomanga.com) \*
 - [qimanga.com](https://qimanga.com)
 - [sushiscan.net](https://sushiscan.net) \*
 - [tcbonepiecechapters.com (TCB Scans, former tcbscans.com)](https://tcbonepiecechapters.com)

--- a/grabber/plainhtmlbrowser.go
+++ b/grabber/plainhtmlbrowser.go
@@ -72,7 +72,7 @@ var browserSelectors = []BrowserSiteSelector{
 		ChaptersWait: "#chapterlist li",
 		ImageWait:    "#readerarea img",
 	},
-	// mangakakalot.gg (manganelo family) behind a cloudflare challenge, needs
+	// mangakakalot.gg (manganelo/manganato family) behind a cloudflare challenge, needs
 	// --browser-visible. Images sit on a CDN that only checks the Referer, so
 	// they still download via plain HTTP (BaseUrl referer is enough).
 	{
@@ -84,7 +84,7 @@ var browserSelectors = []BrowserSiteSelector{
 			Link:         "a",
 			Image:        ".container-chapter-reader img",
 		},
-		Domains:      []string{"mangakakalot.gg"},
+		Domains:      []string{"mangakakalot.gg", "natomanga.com"},
 		ChaptersWait: ".chapter-list .row",
 		ImageWait:    ".container-chapter-reader img",
 	},

--- a/grabber/plainhtmlbrowser_test.go
+++ b/grabber/plainhtmlbrowser_test.go
@@ -14,6 +14,8 @@ func TestMatchBrowserSelector(t *testing.T) {
 		{"sushiscan.net", true},
 		{"mangakakalot.gg", true},
 		{"www.mangakakalot.gg", true},
+		{"natomanga.com", true},
+		{"www.natomanga.com", true}, // www. prefix is stripped
 		{"example.com", false},
 		{"notatoongod.org", false}, // must be an exact host match
 	}

--- a/makefile
+++ b/makefile
@@ -61,7 +61,7 @@ grabber/flamecomics:
 # sites needing a real browser: not part of the `grabber` target since they
 # open a Chrome window and may require solving an interactive challenge
 # (cloudflare). Run them one by one and solve the challenge if prompted.
-grabber/browser: grabber/toongod grabber/dragontea grabber/kappabeast grabber/sushiscan grabber/mangakakalot
+grabber/browser: grabber/toongod grabber/dragontea grabber/kappabeast grabber/sushiscan grabber/mangakakalot grabber/natomanga
 
 grabber/toongod:
 	go run . --browser-visible https://www.toongod.org/webtoon/solo-leveling/ 200
@@ -77,6 +77,9 @@ grabber/sushiscan:
 
 grabber/mangakakalot:
 	go run . --browser-visible https://www.mangakakalot.gg/manga/akuyaku-reijou-kara-no-kareinaru-tenshin-aisare-heroine-anthology-comic 1
+
+grabber/natomanga:
+	go run . --browser-visible https://www.natomanga.com/manga/rebirth-from-0-to-1 205.9
 
 grabber/html: grabber/tcbscans grabber/asura grabber/zonatmo grabber/mangapill
 


### PR DESCRIPTION
This is Claude Fable 5 speaking in behalf of elboletaire.

## Summary

- Adds support for natomanga.com (MangaNato, the successor of manganato.com/manganelo.com) by registering the domain in the existing `BrowserSiteSelector` list in `grabber/plainhtmlbrowser.go`.
- natomanga.com serves its series/reader pages behind a Cloudflare challenge, but its markup is identical to the already-supported mangakakalot.gg (same site family), so no new selector logic is needed — it just piggybacks on the existing mangakakalot entry/selectors.
- The image CDN's Referer requirement is already handled by the existing mangakakalot code path, so no changes were needed there.
- Adds corresponding test cases to `grabber/plainhtmlbrowser_test.go`, updates the `makefile` smoke-test target, and adds the site to the README's supported sites list.

## Testing

- Smoke-tested live against natomanga.com with two chapters (205.8 and 205.9) of a series.
- Resulting CBZs contained 26 and 3 pages respectively; all pages verified as real WebP images via magic bytes.
- Full test suite passes, including the updated selector tests (`go build ./...` and `go test ./...`).

---

Note: this is part of a batch of new-site support PRs being submitted in parallel, so small conflicts in README.md/makefile are expected when merging this one after its siblings.