### PR TITLE
feat(grabber): add manhuaus.com support (Madara, browser-rendered)

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Supported sites
 - [mangakakalot.gg (MangaKakalot)](https://www.mangakakalot.gg) \*
 - [Mangadex](https://mangadex.org)
 - [mangapill.com](https://mangapill.com)
+- [manhuaus.com](https://manhuaus.com) \*
 - [natomanga.com (MangaNato, former manganato.com/manganelo.com)](https://www.natomanga.com) \*
 - [qimanga.com](https://qimanga.com)
 - [sushiscan.net](https://sushiscan.net) \*

--- a/grabber/plainhtmlbrowser.go
+++ b/grabber/plainhtmlbrowser.go
@@ -38,7 +38,7 @@ var browserSelectors = []BrowserSiteSelector{
 			Link:         "a",
 			Image:        "div.reading-content img",
 		},
-		Domains:      []string{"toongod.org", "dragontea.ink"},
+		Domains:      []string{"toongod.org", "dragontea.ink", "manhuaus.com"},
 		ChaptersWait: "li.wp-manga-chapter",
 		ImageWait:    "div.reading-content",
 	},

--- a/grabber/plainhtmlbrowser_test.go
+++ b/grabber/plainhtmlbrowser_test.go
@@ -16,6 +16,7 @@ func TestMatchBrowserSelector(t *testing.T) {
 		{"www.mangakakalot.gg", true},
 		{"natomanga.com", true},
 		{"www.natomanga.com", true}, // www. prefix is stripped
+		{"manhuaus.com", true},
 		{"example.com", false},
 		{"notatoongod.org", false}, // must be an exact host match
 	}

--- a/makefile
+++ b/makefile
@@ -61,7 +61,7 @@ grabber/flamecomics:
 # sites needing a real browser: not part of the `grabber` target since they
 # open a Chrome window and may require solving an interactive challenge
 # (cloudflare). Run them one by one and solve the challenge if prompted.
-grabber/browser: grabber/toongod grabber/dragontea grabber/kappabeast grabber/sushiscan grabber/mangakakalot grabber/natomanga
+grabber/browser: grabber/toongod grabber/dragontea grabber/kappabeast grabber/sushiscan grabber/mangakakalot grabber/natomanga grabber/manhuaus
 
 grabber/toongod:
 	go run . --browser-visible https://www.toongod.org/webtoon/solo-leveling/ 200
@@ -80,6 +80,9 @@ grabber/mangakakalot:
 
 grabber/natomanga:
 	go run . --browser-visible https://www.natomanga.com/manga/rebirth-from-0-to-1 205.9
+
+grabber/manhuaus:
+	go run . --browser-visible https://manhuaus.com/manga/solo-leveling-ragnarok/ 68
 
 grabber/html: grabber/tcbscans grabber/asura grabber/zonatmo grabber/mangapill
 


### PR DESCRIPTION
This is Claude Fable 5 speaking in behalf of elboletaire.

## Summary

- manhuaus.com is a Madara-based WordPress site sitting behind a Cloudflare managed challenge — both plain HTTP and `admin-ajax.php` requests get the challenge page instead of real content.
- Its rendered markup is identical to the existing toongod/dragontea browser selectors, so this simply adds the domain to that existing `BrowserSiteSelector` entry in `grabber/plainhtmlbrowser.go`, plus a matching test case in `grabber/plainhtmlbrowser_test.go`.
- Images still download over plain HTTP using the harvested Cloudflare clearance cookies, same as the other browser-rendered sites.

## Testing

- Smoke-tested live against Solo Leveling: Ragnarok chapters 67-68: produced CBZs with 13/14 real WebP pages, verified via magic bytes.
- Full test suite passes, including the new selector test case.

## Note

Part of a batch of new-site PRs — small conflicts in `README.md`/`makefile` are expected when merging this after its siblings.