### PR TITLE
feat(grabber): add weebcentral.com support

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Supported sites
 - [sushiscan.net](https://sushiscan.net) \*
 - [tcbonepiecechapters.com (TCB Scans, former tcbscans.com)](https://tcbonepiecechapters.com)
 - [toongod.org](https://www.toongod.org) \*
+- [weebcentral.com](https://weebcentral.com)
 - [zonatmo.org (TuMangaOnline, former zonatmo.com)](https://zonatmo.org)
 
 > \* These sites can't be scraped with plain HTTP requests (they render with

--- a/grabber/site.go
+++ b/grabber/site.go
@@ -79,8 +79,10 @@ type Site interface {
 // IdentifySite returns the site passing the Test() for the specified url
 func (g *Grabber) IdentifySite() (Site, []error) {
 	sites := []Site{
-		// PlainHTMLBrowser matches by domain (no fetch), so it goes first
+		// PlainHTMLBrowser and WeebCentral match by domain (no fetch), so
+		// they go first
 		NewPlainHTMLBrowser(g),
+		NewWeebCentral(g),
 		NewPlainHTML(g),
 		NewInmanga(g),
 		NewMangadex(g),

--- a/grabber/weebcentral.go
+++ b/grabber/weebcentral.go
@@ -1,0 +1,175 @@
+package grabber
+
+import (
+	"fmt"
+	"net/url"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"github.com/PuerkitoBio/goquery"
+	"github.com/elboletaire/manga-downloader/http"
+)
+
+// WeebCentral is a grabber for weebcentral.com. It's an HTMX-based site:
+// series pages only render the newest chapter, so the full chapters list
+// needs to be fetched from a separate HTML fragment endpoint
+// (/series/{id}/full-chapter-list), and chapter reader pages load their
+// images from another fragment endpoint that additionally requires a
+// `reading_style=long_strip` query param to return all pages in one shot
+// (found via tools/probe with PROBE_NETLOG, since a plain curl of the
+// hx-get URL alone 400s).
+type WeebCentral struct {
+	*Grabber
+	title string
+}
+
+func NewWeebCentral(g *Grabber) *WeebCentral {
+	return &WeebCentral{Grabber: g}
+}
+
+// WeebCentralChapter represents a WeebCentral Chapter
+type WeebCentralChapter struct {
+	Chapter
+	// URL is the chapter reader page URL
+	URL string
+}
+
+// weebCentralHostRe matches weebcentral.com and its subdomains
+var weebCentralHostRe = regexp.MustCompile(`(?i)(^|\.)weebcentral\.com$`)
+
+// weebCentralSeriesRe extracts the series ULID from a series URL, i.e.
+// "01J76XYDXH7KT6AABVG3JAT3ZP" from
+// https://weebcentral.com/series/01J76XYDXH7KT6AABVG3JAT3ZP/Some-Manga
+var weebCentralSeriesRe = regexp.MustCompile(`/series/([A-Za-z0-9]+)`)
+
+// Test returns true if the URL is a weebcentral.com URL. It only checks the
+// hostname (no fetch) so it can be tried early without extra requests.
+func (w *WeebCentral) Test() (bool, error) {
+	u, err := url.Parse(w.URL)
+	if err != nil {
+		return false, nil
+	}
+
+	return weebCentralHostRe.MatchString(u.Hostname()), nil
+}
+
+// FetchTitle fetches and returns the manga title
+func (w *WeebCentral) FetchTitle() (string, error) {
+	if w.title != "" {
+		return w.title, nil
+	}
+
+	body, err := http.Get(http.RequestParams{
+		URL: w.URL,
+	})
+	if err != nil {
+		return "", err
+	}
+	defer body.Close()
+
+	doc, err := goquery.NewDocumentFromReader(body)
+	if err != nil {
+		return "", err
+	}
+
+	w.title = sanitizeTitle(doc.Find("h1").First().Text())
+
+	return w.title, nil
+}
+
+// FetchChapters returns the chapters of the manga
+func (w WeebCentral) FetchChapters() (chapters Filterables, errs []error) {
+	id, err := w.seriesID()
+	if err != nil {
+		return nil, []error{err}
+	}
+
+	uri, _ := url.JoinPath(w.BaseUrl(), "series", id, "full-chapter-list")
+	body, err := http.Get(http.RequestParams{
+		URL:     uri,
+		Referer: w.URL,
+	})
+	if err != nil {
+		return nil, []error{err}
+	}
+	defer body.Close()
+
+	doc, err := goquery.NewDocumentFromReader(body)
+	if err != nil {
+		return nil, []error{err}
+	}
+
+	doc.Find(`a[href*="/chapters/"]`).Each(func(i int, s *goquery.Selection) {
+		href := strings.TrimSpace(s.AttrOr("href", ""))
+		if href == "" {
+			return
+		}
+
+		number, ok := parseChapterNumber(s.Text())
+		if !ok {
+			return
+		}
+
+		chapters = append(chapters, &WeebCentralChapter{
+			Chapter{
+				Number: number,
+				Title:  "Chapter " + strconv.FormatFloat(number, 'f', -1, 64),
+			},
+			href,
+		})
+	})
+
+	return chapters, nil
+}
+
+// FetchChapter fetches a chapter and its pages
+func (w WeebCentral) FetchChapter(f Filterable) (*Chapter, error) {
+	wchap := f.(*WeebCentralChapter)
+
+	uri := fmt.Sprintf("%s/images?is_prev=False&current_page=1&reading_style=long_strip", wchap.URL)
+	body, err := http.Get(http.RequestParams{
+		URL:     uri,
+		Referer: wchap.URL,
+	})
+	if err != nil {
+		return nil, err
+	}
+	defer body.Close()
+
+	doc, err := goquery.NewDocumentFromReader(body)
+	if err != nil {
+		return nil, err
+	}
+
+	chapter := &Chapter{
+		Title:    f.GetTitle(),
+		Number:   f.GetNumber(),
+		Language: "en",
+	}
+
+	doc.Find("img").Each(func(i int, s *goquery.Selection) {
+		src := strings.TrimSpace(s.AttrOr("src", ""))
+		if src == "" {
+			return
+		}
+		chapter.Pages = append(chapter.Pages, Page{
+			Number: int64(len(chapter.Pages) + 1),
+			URL:    src,
+		})
+	})
+	chapter.PagesCount = int64(len(chapter.Pages))
+
+	return chapter, nil
+}
+
+// seriesID returns the series ULID from the URL (i.e.
+// "01J76XYDXH7KT6AABVG3JAT3ZP" for
+// https://weebcentral.com/series/01J76XYDXH7KT6AABVG3JAT3ZP/Some-Manga)
+func (w WeebCentral) seriesID() (string, error) {
+	matches := weebCentralSeriesRe.FindStringSubmatch(w.URL)
+	if len(matches) != 2 {
+		return "", fmt.Errorf("could not find series id in url %s", w.URL)
+	}
+	return matches[1], nil
+}

--- a/makefile
+++ b/makefile
@@ -33,7 +33,7 @@ else
 	go test -v ./...
 endif
 
-grabber: grabber/inmanga grabber/mangadex grabber/mangabats grabber/mangafire grabber/qimanga grabber/tcb grabber/flamecomics grabber/html
+grabber: grabber/inmanga grabber/mangadex grabber/mangabats grabber/mangafire grabber/qimanga grabber/tcb grabber/flamecomics grabber/weebcentral grabber/html
 
 grabber/inmanga:
 	go run . https://inmanga.com/ver/manga/One-Piece/dfc7ecb5-e9b3-4aa5-a61b-a498993cd935 1187
@@ -57,6 +57,9 @@ grabber/tcb:
 
 grabber/flamecomics:
 	go run . https://flamecomics.xyz/series/154 104
+
+grabber/weebcentral:
+	go run . https://weebcentral.com/series/01J76XYDXH7KT6AABVG3JAT3ZP/Shangri-La-Frontier 274
 
 # sites needing a real browser: not part of the `grabber` target since they
 # open a Chrome window and may require solving an interactive challenge


### PR DESCRIPTION
This is Claude Fable 5 speaking in behalf of elboletaire.

## Summary

- Adds a dedicated grabber for weebcentral.com, an HTMX-based site.
- Series pages only render the newest chapter, so the grabber fetches the full chapter list from the site's `/series/{id}/full-chapter-list` HTML fragment.
- Reader images come from a `/chapters/{id}/images` fragment that requires a `reading_style=long_strip` query param (discovered by capturing the browser's network traffic) to return all pages in a single request.
- Plain HTTP end to end, no browser needed.

## Test plan

- [x] Smoke-tested live with Shangri-La Frontier chapters 273-274 — CBZs produced with 18 real JPEG pages each, verified via magic bytes.
- [x] `go build ./...` passes.
- [x] `go test ./...` passes (full suite, 25 tests across 10 packages).

---

Part of a batch of new-site PRs; small conflicts in README.md, makefile, and grabber/site.go are expected when merging after sibling PRs.