### PR TITLE
feat(grabber): add manhuaplus.com support

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Supported sites
 - [mangakakalot.gg (MangaKakalot)](https://www.mangakakalot.gg) \*
 - [Mangadex](https://mangadex.org)
 - [mangapill.com](https://mangapill.com)
+- [manhuaplus.com](https://manhuaplus.com)
 - [manhuaus.com](https://manhuaus.com) \*
 - [natomanga.com (MangaNato, former manganato.com/manganelo.com)](https://www.natomanga.com) \*
 - [qimanga.com](https://qimanga.com)

--- a/grabber/plainhtml.go
+++ b/grabber/plainhtml.go
@@ -87,6 +87,18 @@ func (m *PlainHTML) Test() (bool, error) {
 			Rows:  "#chapters [data-filter-list] a",
 			Image: "img.js-page",
 		},
+		// manhuaplus.com: Madara wordpress theme, but (unlike the
+		// toongod/dragontea/manhuaus group in plainhtmlbrowser.go) it isn't
+		// cloudflare-walled and the full chapter list is already in the
+		// static HTML (no ajax pagination), so it works over plain HTTP.
+		{
+			Title:        "h1",
+			Rows:         "li.wp-manga-chapter",
+			Chapter:      "a",
+			ChapterTitle: "a",
+			Link:         "a",
+			Image:        "div.reading-content img",
+		},
 	}
 
 	// for the same priority reasons, we need to iterate over the selectors

--- a/makefile
+++ b/makefile
@@ -95,7 +95,7 @@ grabber/natomanga:
 grabber/manhuaus:
 	go run . --browser-visible https://manhuaus.com/manga/solo-leveling-ragnarok/ 68
 
-grabber/html: grabber/tcbscans grabber/asura grabber/zonatmo grabber/mangapill
+grabber/html: grabber/tcbscans grabber/asura grabber/zonatmo grabber/mangapill grabber/manhuaplus
 
 grabber/tcbscans:
 	go run . https://tcbonepiecechapters.com/mangas/5/one-piece 1100
@@ -108,3 +108,6 @@ grabber/zonatmo:
 
 grabber/mangapill:
 	go run . https://mangapill.com/manga/2/one-piece 1188
+
+grabber/manhuaplus:
+	go run . https://manhuaplus.com/manga/tales-of-demons-and-gods01/ 522.6


### PR DESCRIPTION
This is Claude Sonnet (an agent orchestrated by Claude Fable 5) speaking on behalf of elboletaire.

## Path chosen: A (plain HTML)

manhuaplus.com is a Madara wordpress theme, same family as the cloudflare-walled toongod/dragontea/manhuaus group already handled by `PlainHTMLBrowser`, but it isn't cloudflare-walled and isn't JS-rendered: plain `curl` with a browser UA returns the real page (title, chapter list) directly, and the full chapter list is already static HTML with no ajax pagination (unlike lhtranslation.net's `tcb.go`, which needs an ajax POST for its paginated list). So it only needed a new `SiteSelector` entry appended to the list in `grabber/plainhtml.go` → `Test()`, reusing the exact same selectors (`li.wp-manga-chapter` / `div.reading-content img`) as the browser-based Madara group, but served over plain HTTP.

The new entry is appended at the end of the selectors list, so by construction it cannot shadow any earlier (existing) site's `Rows` match; the live end-to-end run below confirms it wasn't shadowed by an earlier entry either (it fetched the correct title/chapters). Per the task constraints, the umbrella `make grabber/html` smoke target was **not** run — only the new `grabber/manhuaplus` target was exercised live.

## Testing

- Series URL: `https://manhuaplus.com/manga/tales-of-demons-and-gods01/` (popular, actively updated series — newest chapter was published "25 seconds ago" at investigation time; used chapter 522.6 instead, a fully-settled recent chapter, per the "don't test the just-published one" guidance).
- Command: `go run . https://manhuaplus.com/manga/tales-of-demons-and-gods01/ 522.6`
- `go build ./...` and `go test ./...` pass (33 tests, 10 packages).

### CBZ verification

```
Archive:  Tales Of Demons And Gods 522.6 - Chapter 522.6.cbz
  Length      Date    Time    Name
---------  ---------- -----   ----
   436997  00-00-1980 00:00   000.jpg
   414590  00-00-1980 00:00   001.jpg
   352667  00-00-1980 00:00   002.jpg
   364018  00-00-1980 00:00   003.jpg
   364784  00-00-1980 00:00   004.jpg
   421261  00-00-1980 00:00   005.jpg
   344645  00-00-1980 00:00   006.jpg
   318662  00-00-1980 00:00   007.jpg
   453611  00-00-1980 00:00   008.jpg
---------                     -------
  3471235                     9 files
```

First and last entry magic bytes both `ff d8 ff e0 00 10 4a 46 49 46` — real JPEGs, matching the 9 `<img>` tags found in the reader page HTML. Images are served from `cdn.manhuaplus.com` and download fine over plain HTTP with just the standard `http` package headers (browser UA + trailing-slash Referer) — no cookies/browser session needed.

## Files changed

- `grabber/plainhtml.go`: new `SiteSelector` entry (Path A, appended last).
- `makefile`: `grabber/manhuaplus` smoke target, wired into `grabber/html`.
- `README.md`: added to supported sites list (no browser-requirement footnote).

## Caveats

- No existing GitHub issue requested this site, so there's no `Closes #N` to reference.
- Chapter numbers are parsed via the existing shared `chapterNumberRe`/anchor-text logic; sub-chapters like "522.6" parse correctly as floats (verified live).
- Didn't add an `AGENTS.md` note — nothing non-obvious was learned; this is a textbook plain-HTTP Madara site.