### PR TITLE
fix(docker): drop privileges instead of recursive chown on mounted volumes

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,6 +227,16 @@ docker run --rm -it -v $PWD:/downloads elboletaire/manga-downloader --help
 Note the `-v $PWD:/downloads` param: it's required in order to get the
 downloaded files in your current folder.
 
+The container writes files as the UID/GID given by the `USER_ID` and
+`GROUP_ID` environment variables (both default to `1000`). The mounted
+directory must be writable by that user, which is already the case for
+`-v $PWD:/downloads` when your host UID is `1000`. If your host UID differs,
+pass it explicitly:
+
+~~~bash
+docker run --rm -it -e USER_ID=$(id -u) -e GROUP_ID=$(id -g) -v "$PWD:/downloads" elboletaire/manga-downloader --help
+~~~
+
 </details>
 
 ## Usage

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -22,6 +22,11 @@ FROM alpine:latest
 
 WORKDIR /app
 
+# su-exec lets the root entrypoint drop privileges to a non-root user before
+# exec'ing manga-downloader, so files are written with the right ownership
+# from the start — no destructive recursive chown of a mounted volume.
+RUN apk add --no-cache su-exec
+
 RUN mkdir /downloads
 
 # Copy the pre-built binary file from the previous stage

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,11 +1,27 @@
 #!/bin/sh
+set -e
 
 # default user id and group id
-USER_ID=${USER_ID:-1000}
-GROUP_ID=${GROUP_ID:-1000}
+USER_ID="${USER_ID:-1000}"
+GROUP_ID="${GROUP_ID:-1000}"
 
-# execute the manga-downloader binary with all arguments passed to this script
-manga-downloader "$@"
+# Set up a runtime user matching the requested UID/GID so files are written
+# with the correct ownership from the start. Only /etc/passwd and /etc/group
+# are touched — never the mounted volume.
+if ! getent group manga >/dev/null 2>&1; then
+    addgroup -g "${GROUP_ID}" manga 2>/dev/null || addgroup manga
+fi
+if ! id manga >/dev/null 2>&1; then
+    adduser -D -H -u "${USER_ID}" -G manga manga 2>/dev/null || \
+        adduser -D -H -u "${USER_ID}" manga
+fi
 
-# Set ownership to USER_ID:GROUP_ID for /downloads
-chown -R ${USER_ID}:${GROUP_ID} /downloads
+# Ensure the top-level /downloads dir is writable by the runtime user.
+# Non-recursive on purpose: a mounted host volume is left untouched beyond
+# this single directory node (already owned by the user in the common
+# -v $PWD:/downloads case, so this is a no-op there).
+chown "${USER_ID}:${GROUP_ID}" /downloads 2>/dev/null || true
+
+# Drop root and run manga-downloader as the non-root user. exec keeps
+# manga-downloader as PID 1 so SIGINT/SIGTERM are delivered directly.
+exec su-exec manga manga-downloader "$@"


### PR DESCRIPTION
GLM-5.2 here, controlled by elboletaire.

## Problem

The Docker entrypoint ran `chown -R \${USER_ID}:\${GROUP_ID} /downloads` after every run. Since the canonical usage (`README.md`) is `-v \$PWD:/downloads`, `/downloads` is a bind mount of a host directory, so this recursively rewrote ownership of **every pre-existing file** in that folder — not just the new CBZ files. Three concrete consequences:

- **Destructive to existing files** — mounting a folder with other content (or worse, a home dir) silently changes ownership of everything inside it.
- **Runs as root, chowns after** — if the user hits Ctrl-C before the chown, partial output is left owned by root and un-deletable without `sudo`.
- **Masks real errors** — a deferred chown instead of surfacing "this mount isn't writable by the configured user".

## Fix

Switch to the standard `su-exec` privilege-drop pattern (used by the nginx/postgres/redis/mysql official images):

- Install `su-exec` (~10KB) in the final alpine stage. Available on both `linux/amd64` and `linux/arm64`, so the multi-platform CI build is unaffected.
- The entrypoint creates a `manga` user/group from `USER_ID`/`GROUP_ID` (defaults 1000:1000), then `exec su-exec manga manga-downloader "\$@"` so the process runs as that user from the start. Files are written with the correct ownership immediately.
- The `chown` of `/downloads` is now **non-recursive** — it only touches the single top-level directory node, never the contents of a mounted host volume (and is a no-op for the common `-v \$PWD:/downloads` case where the mount is already owned by the user).
- `USER_ID`/`GROUP_ID` env vars are preserved for hosts whose UID ≠ 1000.

## Verification

Built the image and confirmed:

- **Build** succeeds.
- **Runs as non-root** — the process reports `uid=1000(manga)`, output files owned by UID 1000, not root.
- **No recursive chown** — files inside the mount owned by UID 999 (at root and nested in a subdir) stay `999:999` after a run; the old image would have rewritten them to `1000:1000`.
- **UID override** — with `-e USER_ID=1234 -e GROUP_ID=5678`, the process drops to 1234 and surfaces a real "Permission denied" against a mount owned by 1000, instead of silently running as root and chowning afterward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)