### PR TITLE
fix(grabber): sort baozimh multi-part chapters deterministically

### DIFF
--- a/grabber/baozimh.go
+++ b/grabber/baozimh.go
@@ -91,6 +91,34 @@ func baozimhChapterNumber(text string) (float64, bool) {
 	return number, true
 }
 
+// baozimhPartRe matches the trailing part marker of a multi-part chapter title
+// ("（上）/（中）/（下）" in either paren style - the site mixes fullwidth and
+// halfwidth parens, e.g. "37 准备行动(上）"). The base part of a split chapter
+// (e.g. "065 资格") carries no such marker.
+var baozimhPartRe = regexp.MustCompile(`[（(]([上中下])[）)]$`)
+
+// baozimhPartOrder returns the reading order of a multi-part chapter entry, so
+// that same-numbered parts sort base → 上 → 中 → 下: "065 资格" before
+// "065 资格（下）", "062 校园（上）" before "062 校园（中）" before "062 校园（下）".
+// It feeds Chapter.SortOrder, which Filterables.SortByNumber uses to break
+// ties between chapters sharing a Number (sort.Slice is unstable, so without
+// it the parts would come out in an arbitrary - and run-varying - order).
+func baozimhPartOrder(title string) float64 {
+	m := baozimhPartRe.FindStringSubmatch(title)
+	if len(m) == 0 {
+		return 0
+	}
+	switch m[1] {
+	case "上":
+		return 1
+	case "中":
+		return 2
+	case "下":
+		return 3
+	}
+	return 0
+}
+
 // Test returns true if the URL points at any of the baozimh domains. The site
 // geo-routes visitors across baozimh.com (both scripts), the cn.bzmgcn.com
 // simplified mirror it redirects mainland-China visitors to, and the
@@ -188,8 +216,9 @@ func (m *Baozimh) FetchChapters() (chapters Filterables, errs []error) {
 
 		chapters = append(chapters, &BaozimhChapter{
 			Chapter{
-				Number: number,
-				Title:  title,
+				Number:    number,
+				Title:     title,
+				SortOrder: baozimhPartOrder(title),
 			},
 			u,
 		})
@@ -280,6 +309,10 @@ func (m *Baozimh) FetchChapter(f Filterable) (*Chapter, error) {
 	return &Chapter{
 		Title:      f.GetTitle(),
 		Number:     f.GetNumber(),
+		// the bundle re-sorts the downloaded chapters by number, so the part
+		// order must survive the FetchChapter round-trip or the 上/中/下 parts
+		// of a split chapter get scrambled again
+		SortOrder:  mchap.GetSortOrder(),
 		PagesCount: int64(len(pages)),
 		Language:   "zh",
 		Pages:      pages,

--- a/grabber/baozimh_test.go
+++ b/grabber/baozimh_test.go
@@ -67,6 +67,67 @@ func TestBaozimhChapterNumber(t *testing.T) {
 	}
 }
 
+func TestBaozimhPartOrder(t *testing.T) {
+	tests := []struct {
+		in   string
+		want float64
+	}{
+		// the base part of a split chapter has no marker and sorts first
+		{"065 资格", 0},
+		{"034 功劳", 0},
+		{"054 选择", 0},
+		// marked parts sort 上 → 中 → 下
+		{"062 校园（上）", 1},
+		{"062 校园（中）", 2},
+		{"062 校园（下）", 3},
+		// the site mixes fullwidth and halfwidth parens
+		{"37 准备行动(上）", 1},
+		{"45 被捕(上）", 1},
+		{"051 宅(上）", 1},
+		{"059 万一（下）", 3},
+		// a (k/M) reader-part suffix is not a 上/中/下 marker
+		{"第100話(2/2)", 0},
+		// a numbered chapter title with no part marker
+		{"001 传染", 0},
+	}
+	for _, tt := range tests {
+		if got := baozimhPartOrder(tt.in); got != tt.want {
+			t.Errorf("baozimhPartOrder(%q) = %v, want %v", tt.in, got, tt.want)
+		}
+	}
+}
+
+func TestSortByNumberTiebreak(t *testing.T) {
+	// the downloader sorts by number with an unstable sort.Slice; without a
+	// tiebreak the 上/中/下 parts of a split chapter (which share a number) can
+	// come out in any order, and in a different order between the fetch-time
+	// sort and the bundle's post-download re-sort
+	chapters := Filterables{
+		&BazCh{Chapter{Number: 62, Title: "062 校园（下）", SortOrder: 3}},
+		&BazCh{Chapter{Number: 1, Title: "001 传染", SortOrder: 0}},
+		&BazCh{Chapter{Number: 62, Title: "062 校园（中）", SortOrder: 2}},
+		&BazCh{Chapter{Number: 62, Title: "062 校园（上）", SortOrder: 1}},
+	}
+
+	sorted := chapters.SortByNumber()
+	want := []string{"001 传染", "062 校园（上）", "062 校园（中）", "062 校园（下）"}
+	for i, w := range want {
+		if sorted[i].GetTitle() != w {
+			t.Errorf("sorted[%d].GetTitle() = %q, want %q (full order: %q)", i, sorted[i].GetTitle(), w, titlesOf(sorted))
+		}
+	}
+}
+
+type BazCh struct{ Chapter }
+
+func titlesOf(f Filterables) []string {
+	out := make([]string, len(f))
+	for i, c := range f {
+		out[i] = c.GetTitle()
+	}
+	return out
+}
+
 func TestBaozimhNextPartURL(t *testing.T) {
 	tests := []struct {
 		name string

--- a/grabber/chapter.go
+++ b/grabber/chapter.go
@@ -10,6 +10,14 @@ type Chapter struct {
 	Title string
 	// Number is the chapter number
 	Number float64
+	// SortOrder is a secondary sort key for chapters that share a Number. Some
+	// sites split a single chapter into several same-numbered entries (e.g.
+	// baozimh's "065 资格" / "065 资格（下）", or "062 校园（上/中/下）"); the
+	// downloader sorts by Number with an unstable sort.Slice, so without a
+	// deterministic tiebreak those parts' relative order is arbitrary - and can
+	// even differ between the fetch-time sort and the post-download re-sort in
+	// bundle mode. Grabbers set it to the parts' reading order (base, 上, 中, 下).
+	SortOrder float64
 	// PagesCount is the number of pages in the chapter
 	PagesCount int64
 	// Pages is the list of pages in the chapter
@@ -33,6 +41,11 @@ type Page struct {
 // GetNumber returns the chapter number
 func (c Chapter) GetNumber() float64 {
 	return c.Number
+}
+
+// GetSortOrder returns the secondary sort key (0 for most chapters)
+func (c Chapter) GetSortOrder() float64 {
+	return c.SortOrder
 }
 
 // GetTitle returns the chapter title removing whitespace and newlines

--- a/grabber/filterable.go
+++ b/grabber/filterable.go
@@ -51,10 +51,32 @@ func (f Filterables) FilterRanges(rngs []ranges.Range) Filterables {
 	return chaps
 }
 
+// ordered is implemented by Filterables that carry a secondary sort key
+// (Chapter.SortOrder) for breaking ties between chapters sharing a Number
+type ordered interface {
+	GetSortOrder() float64
+}
+
 // SortByNumber sorts Filterables by Number
 func (f Filterables) SortByNumber() Filterables {
 	sort.Slice(f, func(i, j int) bool {
-		return f[i].GetNumber() < f[j].GetNumber()
+		if f[i].GetNumber() != f[j].GetNumber() {
+			return f[i].GetNumber() < f[j].GetNumber()
+		}
+
+		// sort.Slice is unstable, so same-numbered chapters (e.g. a baozimh
+		// chapter split into 上/中/下 parts shares a number) would otherwise
+		// come out in an arbitrary order - one that can even differ between
+		// the fetch-time sort and the post-download re-sort in bundle mode.
+		// Tie-break on the part order when the Filterable carries one.
+		var oi, oj float64
+		if x, ok := f[i].(ordered); ok {
+			oi = x.GetSortOrder()
+		}
+		if x, ok := f[j].(ordered); ok {
+			oj = x.GetSortOrder()
+		}
+		return oi < oj
 	})
 
 	return f


### PR DESCRIPTION
Multi-part baozimh chapters share a Number ("065 资格" / "065 资格（下）",
"062 校园（上/中/下）"), and Filterables.SortByNumber uses a non-stable
sort.Slice, so their relative order is arbitrary. In bundle mode the
downloaded chapters are collected in goroutine-completion order and
re-sorted after download (cmd/root.go), scrambling the 上/中/下 parts
into a run-varying order.

Add a SortOrder tiebreak key to Chapter, parsed from the title's part
marker (base=0, 上=1, 中=2, 下=3), carried through FetchChapter, and
used by SortByNumber when two chapters share a Number. Split chapters
now pack in reading order regardless of download completion order.
