### PR TITLE
feat(grabber): support sacachispa.site

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ MangaDex, MangaFire or MangaPark to individual scanlation groups:
 - [ritharscans.com](https://ritharscans.com)
 - [rokaricomics.com](https://rokaricomics.com)
 - [roliascan.com](https://roliascan.com)
+- [sacachispa.site](https://sacachispa.site)
 - [sanascans.com (Sana Scans)](https://sanascans.com)
 - [setsuscans.com](https://setsuscans.com) \*
 - [silentquill.net (Armageddon Scanlation)](https://www.silentquill.net)

--- a/grabber/sacachispa.go
+++ b/grabber/sacachispa.go
@@ -1,0 +1,205 @@
+// Copyright (C) 2023-2026 Òscar Casajuana Alonso
+
+package grabber
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/elboletaire/manga-downloader/http"
+)
+
+// Sacachispa is a grabber for sacachispa.site, an English scanlation site on
+// the Next.js App Router. Like team-shadowi, the series page streams its whole
+// dataset through the `self.__next_f.push` RSC flight payload, including every
+// chapter's already-resolved page-image URLs, so a single fetch covers the
+// title, the chapters and their pages. The DOM itself renders only a handful
+// of chapter links (the first plus the latest few), so a selector-driven
+// grabber would silently miss most chapters.
+type Sacachispa struct {
+	*Grabber
+	data *sacachispaSeriesData
+}
+
+func NewSacachispa(g *Grabber) *Sacachispa {
+	return &Sacachispa{Grabber: g}
+}
+
+// SacachispaChapter represents a sacachispa.site chapter. Its pages are
+// already known from the series page fetch, so FetchChapter needs no further
+// network call.
+type SacachispaChapter struct {
+	Chapter
+	// SourceType is the chapter's hosting backend ("upload" ships the pages
+	// inline; the payload also has imagechest/cubari fields for chapters
+	// hosted elsewhere, which would arrive with no pages at all)
+	SourceType string
+}
+
+// Test returns true if the URL is a sacachispa.site URL
+func (s *Sacachispa) Test() (bool, error) {
+	re := regexp.MustCompile(`sacachispa\.site`)
+	return re.MatchString(s.URL), nil
+}
+
+// FetchTitle fetches and returns the manga title
+func (s *Sacachispa) FetchTitle() (string, error) {
+	data, err := s.fetchData()
+	if err != nil {
+		return "", err
+	}
+
+	return sanitizeTitle(data.Title), nil
+}
+
+// FetchChapters returns the chapters of the manga, including their page
+// images (already embedded in the series page payload)
+func (s *Sacachispa) FetchChapters() (Filterables, []error) {
+	data, err := s.fetchData()
+	if err != nil {
+		return nil, []error{err}
+	}
+
+	chapters := make(Filterables, 0, len(data.Chapters))
+	for _, c := range data.Chapters {
+		title := "Chapter " + formatChapterNumber(c.Number)
+		if t := strings.TrimSpace(c.Title); t != "" {
+			title += " - " + t
+		}
+
+		pages := make([]Page, 0, len(c.Pages))
+		for i, url := range c.Pages {
+			if strings.TrimSpace(url) == "" {
+				continue
+			}
+			pages = append(pages, Page{
+				Number: int64(i + 1),
+				URL:    url,
+			})
+		}
+
+		chapters = append(chapters, &SacachispaChapter{
+			Chapter: Chapter{
+				Number:     c.Number,
+				Title:      title,
+				PagesCount: int64(len(pages)),
+				Pages:      pages,
+				Language:   "en",
+			},
+			SourceType: c.SourceType,
+		})
+	}
+
+	return chapters, nil
+}
+
+// FetchChapter returns the chapter and its pages. The series page fetch
+// (FetchChapters) already carried every chapter's full image list, so there's
+// nothing left to fetch here.
+func (s Sacachispa) FetchChapter(f Filterable) (*Chapter, error) {
+	schap, ok := f.(*SacachispaChapter)
+	if !ok {
+		return nil, errors.New("invalid chapter type")
+	}
+
+	if len(schap.Pages) == 0 {
+		// only "upload" chapters ship their pages in the payload; anything
+		// hosted elsewhere would pack an empty archive, so fail loudly
+		return nil, fmt.Errorf(
+			"no pages found for chapter %s (source type %q isn't hosted on the site)",
+			formatChapterNumber(f.GetNumber()), schap.SourceType,
+		)
+	}
+
+	chapter := schap.Chapter
+
+	return &chapter, nil
+}
+
+// fetchData fetches and caches the series page's embedded RSC payload (title,
+// chapters and each chapter's page images)
+func (s *Sacachispa) fetchData() (*sacachispaSeriesData, error) {
+	if s.data != nil {
+		return s.data, nil
+	}
+
+	body, err := http.GetText(http.RequestParams{
+		URL:     s.seriesURL(),
+		Referer: s.BaseUrl(),
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	data, err := parseSacachispaSeriesData(body)
+	if err != nil {
+		return nil, err
+	}
+
+	s.data = data
+
+	return s.data, nil
+}
+
+// seriesURL maps a chapter URL down to its series URL: chapter pages carry
+// only their own pages in the payload, while the series page carries
+// everything, so the grabber always fetches the latter
+func (s Sacachispa) seriesURL() string {
+	if i := strings.Index(s.URL, "/chapter/"); i != -1 {
+		return s.URL[:i]
+	}
+	return s.URL
+}
+
+// sacachispaTitleRe matches the series title inside the flight stream: the
+// chapters' own "title" keys are null (or live inside the chapters array,
+// after this marker), so anchoring on the sibling seriesId key is what keeps
+// this from ever grabbing a chapter title.
+var sacachispaTitleRe = regexp.MustCompile(`"seriesId":"[^"]*","title":"((?:[^"\\]|\\.)*)"`)
+
+// parseSacachispaSeriesData extracts the series title and the `"chapters":[...]`
+// array embedded in the page's Next.js RSC stream. They live in different
+// react element tuples, so each is extracted on its own.
+func parseSacachispaSeriesData(html string) (*sacachispaSeriesData, error) {
+	stream, err := nextFlightStream(html)
+	if err != nil {
+		return nil, err
+	}
+
+	data := &sacachispaSeriesData{}
+
+	m := sacachispaTitleRe.FindStringSubmatch(stream)
+	if m == nil {
+		return nil, errors.New("no series title found in the page data (is the URL a series page?)")
+	}
+	// the captured group is still JSON-escaped, so decode it as a JSON string
+	if err := json.Unmarshal([]byte(`"`+m[1]+`"`), &data.Title); err != nil {
+		return nil, err
+	}
+
+	raw, err := extractBalancedJSON(stream, `"chapters":`)
+	if err != nil {
+		return nil, err
+	}
+	if err := json.Unmarshal([]byte(raw), &data.Chapters); err != nil {
+		return nil, err
+	}
+
+	return data, nil
+}
+
+// sacachispaSeriesData is the payload embedded in sacachispa.site series pages
+type sacachispaSeriesData struct {
+	Title    string
+	Chapters []struct {
+		// decimals like 8.5 exist, so this must stay a float
+		Number float64 `json:"chapter_number"`
+		// null for most chapters, in which case the site renders "Chapter N"
+		Title      string   `json:"title"`
+		SourceType string   `json:"source_type"`
+		Pages      []string `json:"pages"`
+	}
+}

--- a/grabber/sacachispa_test.go
+++ b/grabber/sacachispa_test.go
@@ -1,0 +1,90 @@
+// Copyright (C) 2023-2026 Òscar Casajuana Alonso
+
+package grabber
+
+import "testing"
+
+func TestSacachispaSeriesData(t *testing.T) {
+	// a trimmed-down series page payload: Next.js streams the RSC data as
+	// several `self.__next_f.push([1,"..."])` chunks and splits it wherever it
+	// likes, so the chapters array below straddles two of them on purpose. The
+	// series title lives in a different react element tuple than the chapters.
+	html := `<script>self.__next_f.push([1,"1d:[\"$\",\"$L21\",null,{\"seriesId\":\"ae6ecebb\",\"title\":\"Some \\\"Quoted\\\" Series\",\"nextChapterNumber\":1}]\n1e:[\"$\",\"$L22\",null,{\"slug\":\"some-series\",\"chapters\":[{\"id\":\"c1\",\"chapter_number\":1,\"title\":null,\"page_count\":2,\"source_type\":\"upload\",\"pages\":[\"https://uwu.sacachispa.site/chapters/x/1/a.jpg\",\"https:"])</script>` +
+		`<script>self.__next_f.push([1,"//uwu.sacachispa.site/chapters/x/1/b.jpg\"]},{\"id\":\"c2\",\"chapter_number\":8.5,\"title\":\"Named one\",\"page_count\":0,\"source_type\":\"cubari\",\"pages\":[]}]}]\n"])</script>`
+
+	data, err := parseSacachispaSeriesData(html)
+	if err != nil {
+		t.Fatalf("parseSacachispaSeriesData() error = %v", err)
+	}
+
+	if data.Title != `Some "Quoted" Series` {
+		t.Errorf("parseSacachispaSeriesData() title = %q, unexpected", data.Title)
+	}
+	if len(data.Chapters) != 2 {
+		t.Fatalf("parseSacachispaSeriesData() got %d chapters, want 2", len(data.Chapters))
+	}
+	// most chapters carry a null title, which is what makes FetchChapters
+	// fall back to "Chapter N"
+	c := data.Chapters[0]
+	if c.Number != 1 || c.Title != "" || c.SourceType != "upload" || len(c.Pages) != 2 {
+		t.Errorf("parseSacachispaSeriesData() chapters[0] = %+v, unexpected", c)
+	}
+	if c.Pages[1] != "https://uwu.sacachispa.site/chapters/x/1/b.jpg" {
+		t.Errorf("parseSacachispaSeriesData() chapters[0].Pages[1] = %q, unexpected", c.Pages[1])
+	}
+	// chapters hosted off-site ship no pages; FetchChapter fails loudly on them
+	c = data.Chapters[1]
+	if c.Number != 8.5 || c.Title != "Named one" || c.SourceType != "cubari" || len(c.Pages) != 0 {
+		t.Errorf("parseSacachispaSeriesData() chapters[1] = %+v, unexpected", c)
+	}
+
+	if _, err := parseSacachispaSeriesData("no payload here"); err == nil {
+		t.Error("parseSacachispaSeriesData() with no __next_f payload should error")
+	}
+	// a chapter page has a flight payload too, but no seriesId+title tuple
+	if _, err := parseSacachispaSeriesData(`<script>self.__next_f.push([1,"8:{\"pages\":[\"a.jpg\"]}"])</script>`); err == nil {
+		t.Error("parseSacachispaSeriesData() without a series title should error")
+	}
+}
+
+func TestSacachispaSeriesURL(t *testing.T) {
+	cases := []struct {
+		url  string
+		want string
+	}{
+		{"https://sacachispa.site/series/some-series", "https://sacachispa.site/series/some-series"},
+		// chapter URLs are mapped down to the series page, which is the one
+		// carrying the full chapter list in its payload
+		{"https://sacachispa.site/series/some-series/chapter/15", "https://sacachispa.site/series/some-series"},
+	}
+
+	for _, c := range cases {
+		s := Sacachispa{Grabber: &Grabber{URL: c.url}}
+		if got := s.seriesURL(); got != c.want {
+			t.Errorf("seriesURL(%q) = %q, want %q", c.url, got, c.want)
+		}
+	}
+}
+
+func TestSacachispaTest(t *testing.T) {
+	cases := []struct {
+		url  string
+		want bool
+	}{
+		{"https://sacachispa.site/series/boku-no-seito-wa-otona-gal", true},
+		{"https://sacachispa.site/series/boku-no-seito-wa-otona-gal/chapter/15", true},
+		{"https://example.com/series/boku-no-seito-wa-otona-gal", false},
+	}
+
+	for _, c := range cases {
+		s := Sacachispa{Grabber: &Grabber{URL: c.url}}
+		got, err := s.Test()
+		if err != nil {
+			t.Errorf("Test(%q) error = %v", c.url, err)
+			continue
+		}
+		if got != c.want {
+			t.Errorf("Test(%q) = %v, want %v", c.url, got, c.want)
+		}
+	}
+}

--- a/grabber/site.go
+++ b/grabber/site.go
@@ -118,6 +118,7 @@ func (g *Grabber) IdentifySite() (Site, []error) {
 		NewMangalib(g),
 		NewMangadenizi(g),
 		NewRoliascan(g),
+		NewSacachispa(g),
 		NewTeamshadowi(g),
 		NewTaiyo(g),
 		NewStonescape(g),

--- a/makefile
+++ b/makefile
@@ -79,6 +79,7 @@ grabber: \
 	grabber/projectsuki \
 	grabber/qimanga \
 	grabber/roliascan \
+	grabber/sacachispa \
 	grabber/stonescape \
 	grabber/taiyo \
 	grabber/tcb \
@@ -231,6 +232,8 @@ grabber/mangataro:
 	go run . https://mangataro.org/manga/one-piece 1188
 grabber/roliascan:
 	go run . https://roliascan.com/manga/no-marriage/ 77
+grabber/sacachispa:
+	go run . https://sacachispa.site/series/boku-no-seito-wa-otona-gal 14
 grabber/teamshadowi:
 	go run . https://www.team-shadowi.com/series/the-regressed-mercenary-has-a-plan 98
 grabber/taiyo:


### PR DESCRIPTION
Fable here, controlled by elboletaire.

Closes #165.

## What

Adds support for [sacachispa.site](https://sacachispa.site) with a dedicated grabber.

## Why a dedicated grabber

The issue was right about there being no Cloudflare — plain curl gets a 200. But it's a Next.js App Router site, and the series page DOM renders only 7 of the 16 chapter links (the first plus the latest few), so a `PlainHTML` selector entry would silently miss most chapters. The full dataset ships in the `self.__next_f.push` RSC flight payload instead — same pattern as team-shadowi, so the grabber reuses `nextFlightStream` + `extractBalancedJSON` and needs exactly **one fetch**: the payload embeds every chapter's already-resolved page-image URLs (`https://uwu.sacachispa.site/chapters/...`), which download over plain HTTP with a referer.

Details:

- Chapter URLs (like the one in the issue) are mapped down to their series page, since chapter pages only carry their own pages in the payload.
- Decimal chapter numbers exist (8.5 on the example series) and are handled.
- The payload has `imagechest_gallery_id`/`cubari_url` fields, so chapters hosted off-site presumably ship with no `pages`; `FetchChapter` fails loudly on those instead of packing an empty archive. Every chapter on the current catalog is `source_type: "upload"` with inline pages.
- The series title is anchored on the `"seriesId":...,"title":...` tuple rather than a bare `"title"` key, so a titled chapter can never shadow it.

## Verification

- `make grabber/sacachispa` (chapter 14, one behind the latest per the paywall rule): 14 pages, 6.0M CBZ, `tools/verify-cbz` OK.
- Chapter-URL form end to end: `go run . https://sacachispa.site/series/boku-no-seito-wa-otona-gal/chapter/15 13` → 20 pages, 10.1M CBZ, `verify-cbz` OK.
- `make test` passes; new unit tests cover the flight-payload parsing (chunk-straddled array, escaped quotes in the title, null chapter titles, decimal numbers, off-site source types), the chapter→series URL mapping, and `Test()`.