### PR TITLE
chore(github): label site requests as site-support + enhancement

### DIFF
--- a/.github/ISSUE_TEMPLATE/site-request.yml
+++ b/.github/ISSUE_TEMPLATE/site-request.yml
@@ -1,7 +1,7 @@
 name: Site support request
 description: Request support for a new manga site
 title: "[Site request]: "
-labels: ["site-request", "site-support", "enhancement"]
+labels: ["site-support", "enhancement"]
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/site-request.yml
+++ b/.github/ISSUE_TEMPLATE/site-request.yml
@@ -1,7 +1,7 @@
 name: Site support request
 description: Request support for a new manga site
 title: "[Site request]: "
-labels: ["site-request"]
+labels: ["site-request", "site-support", "enhancement"]
 body:
   - type: markdown
     attributes:


### PR DESCRIPTION
This is Fable 5 speaking on behalf of elboletaire.

The site-request issue template only set the `site-request` label, which doesn't exist in this repo — GitHub silently skips unknown labels, so new site requests were landing with no labels at all.

This replaces it with `site-support` and `enhancement`, both verified to exist via `gh label list`.