### PR TITLE
fix(mangafire): follow numbered-only pagers so short chapter lists aren't truncated

### DIFF
--- a/cmd/version.go
+++ b/cmd/version.go
@@ -51,5 +51,8 @@ var versionCmd = &cobra.Command{
 }
 
 func init() {
+	// also honor `manga-downloader --version` (what the bug-report template
+	// asks for); cobra handles the flag before requiring the URL argument
+	rootCmd.Version = fmt.Sprintf("%s (%s)", Version, Tag)
 	rootCmd.AddCommand(versionCmd)
 }

--- a/grabber/mangafire.go
+++ b/grabber/mangafire.go
@@ -20,6 +20,16 @@ const mangafireBase = "https://mangafire.to"
 // a runaway loop if the end-of-list detection ever fails.
 const mangafireMaxChapterPages = 400
 
+// mangafireNextPageSelector advances the chapter-list pager one page. The
+// "Next page" arrow only renders when there are more than ~5 pages, so short
+// pagers (numbered buttons only) need the numbered button right after the
+// active one instead; on long pagers the arrow covers the case where the
+// active number is the last of its window. querySelector picks whichever
+// matches first in document order — both advance exactly one page. On the
+// last page neither matches (no numbered sibling, arrow gone/disabled), which
+// ends the pagination loop.
+const mangafireNextPageSelector = `.npager__num.is-active + .npager__num, .npager__nav[aria-label="Next page"]`
+
 // Mangafire is a grabber for mangafire.to. The site is a react SPA whose JSON
 // API signs every request with a per-session, Cloudflare-challenge-gated `vrf`
 // token generated client-side, so the endpoints can no longer be called with
@@ -151,7 +161,7 @@ func (m *Mangafire) load() error {
 		m.URL,
 		".title-detail__row-link",
 		"/api/titles/"+hid,
-		`.npager__nav[aria-label="Next page"]`,
+		mangafireNextPageSelector,
 		mangafireMaxChapterPages,
 		0,
 	)
@@ -188,36 +198,8 @@ func (m *Mangafire) load() error {
 		break
 	}
 
-	// second pass: collect chapters, deduping by number and preferring the
-	// official scanlation (the api returns both official and unofficial
-	// uploads for the same number)
-	best := map[float64]mangafireChapterItem{}
-	var order []float64
-	for _, r := range responses {
-		if !strings.Contains(r.URL, chaptersPrefix) {
-			continue
-		}
-		feed := struct {
-			Items []mangafireChapterItem `json:"items"`
-		}{}
-		if err := json.Unmarshal([]byte(r.Body), &feed); err != nil {
-			continue
-		}
-		for _, c := range feed.Items {
-			cur, ok := best[c.Number]
-			if !ok {
-				best[c.Number] = c
-				order = append(order, c.Number)
-				continue
-			}
-			if cur.Type != "official" && c.Type == "official" {
-				best[c.Number] = c
-			}
-		}
-	}
-
-	for _, num := range order {
-		c := best[num]
+	// second pass: collect chapters from every captured feed page
+	for _, c := range parseMangafireChapters(responses, chaptersPrefix) {
 		title := c.Name
 		if title == "" {
 			title = "Chapter " + strconv.FormatFloat(c.Number, 'f', -1, 64)
@@ -253,6 +235,44 @@ func (m *Mangafire) hid() (string, error) {
 		return matches[1], nil
 	}
 	return "", fmt.Errorf("could not find title id in url %s", m.URL)
+}
+
+// parseMangafireChapters collects the chapter items out of the captured API
+// responses whose URL matches chaptersPrefix (one response per chapter-list
+// page), deduping by chapter number and preferring the official scanlation
+// (the api returns both official and unofficial uploads for the same number).
+// Items keep their first-seen order, which is the site's own list order.
+func parseMangafireChapters(responses []browser.APIResponse, chaptersPrefix string) []mangafireChapterItem {
+	best := map[float64]mangafireChapterItem{}
+	var order []float64
+	for _, r := range responses {
+		if !strings.Contains(r.URL, chaptersPrefix) {
+			continue
+		}
+		feed := struct {
+			Items []mangafireChapterItem `json:"items"`
+		}{}
+		if err := json.Unmarshal([]byte(r.Body), &feed); err != nil {
+			continue
+		}
+		for _, c := range feed.Items {
+			cur, ok := best[c.Number]
+			if !ok {
+				best[c.Number] = c
+				order = append(order, c.Number)
+				continue
+			}
+			if cur.Type != "official" && c.Type == "official" {
+				best[c.Number] = c
+			}
+		}
+	}
+
+	out := make([]mangafireChapterItem, 0, len(order))
+	for _, num := range order {
+		out = append(out, best[num])
+	}
+	return out
 }
 
 // mangafireChapterItem is one entry of the chapters-list JSON feed

--- a/grabber/mangafire_test.go
+++ b/grabber/mangafire_test.go
@@ -2,7 +2,11 @@
 
 package grabber
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/elboletaire/manga-downloader/browser"
+)
 
 func TestMangafireHid(t *testing.T) {
 	cases := []struct {
@@ -27,5 +31,72 @@ func TestMangafireHid(t *testing.T) {
 		if got != c.want {
 			t.Errorf("hid(%q) = %q, want %q", c.url, got, c.want)
 		}
+	}
+}
+
+func TestParseMangafireChapters(t *testing.T) {
+	const prefix = "/api/titles/9062q/chapters"
+	page := func(page int, body string) browser.APIResponse {
+		return browser.APIResponse{
+			URL:  "https://mangafire.to" + prefix + "?language=en&sort=number&order=desc&page=" + string(rune('0'+page)) + "&limit=20&vrf=x",
+			Body: body,
+		}
+	}
+
+	cases := []struct {
+		name      string
+		responses []browser.APIResponse
+		wantNums  []float64
+		wantTypes map[float64]string
+	}{
+		{
+			// the #169 regression: chapters spread over several pager pages
+			// (sorted descending by the site) must all be collected, in order
+			name: "multiple pages merge",
+			responses: []browser.APIResponse{
+				page(1, `{"items":[{"id":3,"number":3,"name":"C3","language":"en","type":"official"},{"id":2,"number":2,"name":"C2","language":"en","type":"official"}]}`),
+				page(2, `{"items":[{"id":1,"number":1,"name":"C1","language":"en","type":"official"}]}`),
+			},
+			wantNums: []float64{3, 2, 1},
+		},
+		{
+			name: "official preferred over unofficial regardless of order",
+			responses: []browser.APIResponse{
+				page(1, `{"items":[{"id":10,"number":1,"type":"unofficial"},{"id":11,"number":1,"type":"official"},{"id":21,"number":2,"type":"official"},{"id":20,"number":2,"type":"unofficial"}]}`),
+			},
+			wantNums:  []float64{1, 2},
+			wantTypes: map[float64]string{1: "official", 2: "official"},
+		},
+		{
+			name: "non-matching and malformed responses are skipped",
+			responses: []browser.APIResponse{
+				{URL: "https://mangafire.to/api/titles/9062q?vrf=x", Body: `{"data":{"title":"nope"}}`},
+				page(1, `not json`),
+				page(2, `{"items":[{"id":1,"number":1,"type":"official"}]}`),
+			},
+			wantNums: []float64{1},
+		},
+		{
+			name:      "no responses yields empty list",
+			responses: nil,
+			wantNums:  []float64{},
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := parseMangafireChapters(c.responses, prefix)
+			if len(got) != len(c.wantNums) {
+				t.Fatalf("got %d chapters, want %d (%v)", len(got), len(c.wantNums), got)
+			}
+			for i, item := range got {
+				if item.Number != c.wantNums[i] {
+					t.Errorf("chapter[%d].Number = %v, want %v", i, item.Number, c.wantNums[i])
+				}
+				if want, ok := c.wantTypes[item.Number]; ok && item.Type != want {
+					t.Errorf("chapter %v type = %q, want %q", item.Number, item.Type, want)
+				}
+			}
+		})
 	}
 }

--- a/grabber/mangafire_test.go
+++ b/grabber/mangafire_test.go
@@ -3,8 +3,11 @@
 package grabber
 
 import (
+	"strconv"
+	"strings"
 	"testing"
 
+	"github.com/PuerkitoBio/goquery"
 	"github.com/elboletaire/manga-downloader/browser"
 )
 
@@ -34,11 +37,113 @@ func TestMangafireHid(t *testing.T) {
 	}
 }
 
+// mangafireNextTarget mirrors what the click JS in browser.captureAPI does with
+// mangafireNextPageSelector: document.querySelector takes the first match in
+// document order, and the click is skipped when that element reports itself
+// disabled. It returns "gone" (pagination ends), "disabled" (ditto), or the
+// label of the button that would be clicked.
+func mangafireNextTarget(t *testing.T, pager string) string {
+	t.Helper()
+	doc, err := goquery.NewDocumentFromReader(strings.NewReader(pager))
+	if err != nil {
+		t.Fatalf("parsing pager fixture: %v", err)
+	}
+	b := doc.Find(mangafireNextPageSelector).First()
+	if b.Length() == 0 {
+		return "gone"
+	}
+	if _, ok := b.Attr("disabled"); ok {
+		return "disabled"
+	}
+	if v, _ := b.Attr("aria-disabled"); v == "true" {
+		return "disabled"
+	}
+	return strings.TrimSpace(b.Text())
+}
+
+// TestMangafireNextPageSelector is the actual #169 regression guard: the bug was
+// that short chapter lists render a numbered-only pager (no "Next page" arrow),
+// so a selector matching only the arrow never advanced and the list was silently
+// truncated to the first page. Reverting mangafireNextPageSelector to the
+// arrow-only selector must fail the "numbered-only" cases below.
+func TestMangafireNextPageSelector(t *testing.T) {
+	// short list: numbered buttons only, no arrows at all
+	numbered := func(active int) string {
+		var sb strings.Builder
+		sb.WriteString(`<div class="npager">`)
+		for n := 1; n <= 3; n++ {
+			cls := "npager__num"
+			if n == active {
+				cls += " is-active"
+			}
+			sb.WriteString(`<a class="` + cls + `">` + strconv.Itoa(n) + `</a>`)
+		}
+		sb.WriteString(`</div>`)
+		return sb.String()
+	}
+
+	cases := []struct {
+		name  string
+		pager string
+		want  string
+	}{
+		{"numbered-only pager, first page", numbered(1), "2"},
+		{"numbered-only pager, middle page", numbered(2), "3"},
+		// no numbered sibling and no arrow: the walk stops here
+		{"numbered-only pager, last page", numbered(3), "gone"},
+		{
+			// windowed pager: the numbered sibling comes first in document
+			// order, and advances exactly one page just like the arrow would
+			name: "windowed pager, active mid-window",
+			pager: `<div class="npager">` +
+				`<a class="npager__nav" aria-label="Previous page">&lsaquo;</a>` +
+				`<a class="npager__num">1</a>` +
+				`<a class="npager__num is-active">2</a>` +
+				`<a class="npager__num">3</a>` +
+				`<a class="npager__nav" aria-label="Next page">&rsaquo;</a>` +
+				`</div>`,
+			want: "3",
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := mangafireNextTarget(t, c.pager); got != c.want {
+				t.Errorf("next target = %q, want %q", got, c.want)
+			}
+		})
+	}
+
+	// the arrow is what covers the case the numbered selector cannot: the active
+	// number is the last of its window but more pages follow
+	t.Run("windowed pager, active last of window", func(t *testing.T) {
+		pager := `<div class="npager">` +
+			`<a class="npager__num">4</a>` +
+			`<a class="npager__num is-active">5</a>` +
+			`<a class="npager__nav" aria-label="Next page">next</a>` +
+			`</div>`
+		if got := mangafireNextTarget(t, pager); got != "next" {
+			t.Errorf("next target = %q, want %q", got, "next")
+		}
+	})
+
+	t.Run("windowed pager, last page with disabled arrow", func(t *testing.T) {
+		pager := `<div class="npager">` +
+			`<a class="npager__num">9</a>` +
+			`<a class="npager__num is-active">10</a>` +
+			`<a class="npager__nav" aria-label="Next page" aria-disabled="true">next</a>` +
+			`</div>`
+		if got := mangafireNextTarget(t, pager); got != "disabled" {
+			t.Errorf("next target = %q, want %q", got, "disabled")
+		}
+	})
+}
+
 func TestParseMangafireChapters(t *testing.T) {
 	const prefix = "/api/titles/9062q/chapters"
 	page := func(page int, body string) browser.APIResponse {
 		return browser.APIResponse{
-			URL:  "https://mangafire.to" + prefix + "?language=en&sort=number&order=desc&page=" + string(rune('0'+page)) + "&limit=20&vrf=x",
+			URL:  "https://mangafire.to" + prefix + "?language=en&sort=number&order=desc&page=" + strconv.Itoa(page) + "&limit=20&vrf=x",
 			Body: body,
 		}
 	}

--- a/makefile
+++ b/makefile
@@ -108,8 +108,13 @@ grabber/mangabats:
 # download over plain HTTP. No --browser-visible needed, so not in the
 # grabber/browser group, but kept out of the CI smoke matrix like every other
 # browser grabber. Uses an old chapter (stable, not premium-gated like newest).
+# The two runs cover both chapter-list pager shapes (#169): One Piece has the
+# windowed pager with "Next page" arrows; the second series is short enough
+# (3 pages) that the site renders numbered buttons only, and its chapter 1
+# lives on the last page — the run exits 1 unless every page was harvested.
 grabber/mangafire:
 	go run . https://mangafire.to/title/dkw-one-piece 1050
+	go run . https://mangafire.to/title/9062q-itoko-no-onee-chan-ni-amaechau 1
 
 grabber/fanfox:
 	go run . https://fanfox.net/manga/chainsaw_man/ 232


### PR DESCRIPTION
This is Claude (Fable 5) speaking on behalf of elboletaire.

Fixes #169.

## Root cause

mangafire's chapter list is fetched by rendering the series page and clicking through the pager while intercepting the signed `/api/titles/{hid}/chapters?...&order=desc&page=N&limit=20` responses. The click loop targeted `.npager__nav[aria-label="Next page"]` — but the site only renders that arrow when the pager has more than ~5 pages. Short series get **numbered buttons only** (`<nav class="npager"><button class="npager__num is-active">1</button><button class="npager__num">2</button>…`), so the loop reported the button "gone" immediately and harvested only page 1: the 20 newest chapters, since the site sorts descending. Exactly what the reporter saw — chapters 26–44 of a 44-chapter series, and "No chapters found" for range `1`.

Both reported symptoms share this single root cause: the "download all" confirmation path has no fetching logic of its own — it iterates the same list `FetchChapters` returned — so it too only ever saw the first page. Completing the harvest fixes the range case and the download-all case alike.

## The fix

The next-page selector is now a list:

```
.npager__num.is-active + .npager__num, .npager__nav[aria-label="Next page"]
```

The numbered button right after the active one advances one page on short pagers; the arrow covers long pagers where the active number is the last of its window. On the last page neither matches, ending the loop as before. The chapters-feed parsing (multi-page merge + official-upload dedup) is extracted into `parseMangafireChapters` so it's unit-testable.

## Grabber audit

A repo-wide audit of the other grabbers for this bug class (truncated/paginated/first-page-only chapter lists) is being done separately and will be reported independently.

## Tests

- `TestParseMangafireChapters` table tests in `grabber/mangafire_test.go`: multi-page merge in site order (the #169 regression shape), official-over-unofficial dedup regardless of order, malformed/non-matching responses skipped, empty input.
- The `grabber/mangafire` smoke target now also runs the reporter's series with range `1`: the series is short enough (3 pager pages, numbered buttons only) that chapter 1 lives on the last page, so the run exits 1 unless every page was harvested — a live completeness assertion for both pager shapes (One Piece 1050 keeps covering the arrow path).

## Verification (live, local Chromium, headless)

- `go run . https://mangafire.to/title/9062q-itoko-no-onee-chan-ni-amaechau --output-dir ... 1` → downloaded; `tools/verify-cbz` OK, 24 pages. (Before the fix this printed "No chapters found for the specified ranges".)
- Same series, range `22` (middle of the list, pager page 2) → verify-cbz OK, 18 pages.
- `go run . https://mangafire.to/title/dkw-one-piece 1000` (long pager, ~8 pages deep) → verify-cbz OK, 17 pages.
- `go run . https://mangafire.to/title/dkw-one-piece 1` (full traversal of the ~58-page windowed pager) → verify-cbz OK, 53 pages.
- Same series, **no range** (the reporter's "download all" scenario): the confirmation prompt now offers all **44** chapters, where before the fix it only offered the first-page window (26–44).
- `make test` and `go vet ./...` pass.

## Also (separate commit)

The bug-report template asks for the output of `manga-downloader --version`, but only the `version` subcommand existed. Cobra's `Version` field is now set, so the flag works (it's handled before the URL argument is required): `manga-downloader --version` → `manga-downloader version v1.8.0 (...)`.
