### PR TITLE
chore(grabber): harden luascans pagination + fix stale comments

### DIFF
--- a/grabber/luascans.go
+++ b/grabber/luascans.go
@@ -58,28 +58,58 @@ func (l *Luascans) FetchTitle() (string, error) {
 	return l.title, nil
 }
 
-// FetchChapters returns the chapters of the manga
+// FetchChapters returns the chapters of the manga. The API paginates (its
+// `meta` carries `last_page`), so keep requesting pages until the last one:
+// a single perPage=200 call would silently truncate the first 200+-chapter
+// series (same pattern as the qimanga & hijala grabbers).
 func (l *Luascans) FetchChapters() (chapters Filterables, errs []error) {
 	seriesID, err := l.fetchSeriesID()
 	if err != nil {
 		return nil, []error{err}
 	}
 
-	uri := fmt.Sprintf(
-		"https://api.luacomic.org/chapter/query?page=1&perPage=200&query=&order=desc&series_id=%s",
-		seriesID,
-	)
-	body, err := http.GetText(http.RequestParams{
-		URL:     uri,
-		Referer: l.URL,
-	})
-	if err != nil {
-		return nil, []error{err}
-	}
+	page := 1
+	for {
+		uri := fmt.Sprintf(
+			"https://api.luacomic.org/chapter/query?page=%d&perPage=200&query=&order=desc&series_id=%s",
+			page,
+			seriesID,
+		)
+		body, err := http.GetText(http.RequestParams{
+			URL:     uri,
+			Referer: l.URL,
+		})
+		if err != nil {
+			errs = append(errs, err)
+			return
+		}
 
-	feed := luascansChaptersFeed{}
+		pageChapters, feed, err := parseLuascansChaptersPage(body)
+		if err != nil {
+			errs = append(errs, err)
+			return
+		}
+		// an empty page also stops the loop, in case the api ever reports a
+		// last_page beyond the actual data
+		if len(feed.Data) == 0 {
+			return
+		}
+		chapters = append(chapters, pageChapters...)
+
+		if page >= feed.Meta.LastPage {
+			return
+		}
+		page++
+	}
+}
+
+// parseLuascansChaptersPage parses a single page of the chapters API feed,
+// returning the chapters it contains plus the decoded feed itself (whose
+// `meta.last_page` and raw data length tell the caller when to stop
+// paginating)
+func parseLuascansChaptersPage(body string) (chapters Filterables, feed luascansChaptersFeed, err error) {
 	if err = json.Unmarshal([]byte(body), &feed); err != nil {
-		return nil, []error{err}
+		return nil, feed, err
 	}
 
 	for _, c := range feed.Data {
@@ -96,7 +126,7 @@ func (l *Luascans) FetchChapters() (chapters Filterables, errs []error) {
 		})
 	}
 
-	return
+	return chapters, feed, nil
 }
 
 // FetchChapter fetches a chapter and its pages
@@ -215,8 +245,12 @@ func (l *Luascans) fetchSeriesID() (string, error) {
 	return l.seriesID, nil
 }
 
-// luascansChaptersFeed is the JSON feed for the chapters list
+// luascansChaptersFeed is the JSON feed for the paginated chapters list
 type luascansChaptersFeed struct {
+	Meta struct {
+		Total    int `json:"total"`
+		LastPage int `json:"last_page"`
+	} `json:"meta"`
 	Data []struct {
 		Name string `json:"chapter_name"`
 		Slug string `json:"chapter_slug"`

--- a/grabber/luascans.go
+++ b/grabber/luascans.go
@@ -62,44 +62,76 @@ func (l *Luascans) FetchTitle() (string, error) {
 // `meta` carries `last_page`), so keep requesting pages until the last one:
 // a single perPage=200 call would silently truncate the first 200+-chapter
 // series (same pattern as the qimanga & hijala grabbers).
-func (l *Luascans) FetchChapters() (chapters Filterables, errs []error) {
+func (l *Luascans) FetchChapters() (Filterables, []error) {
 	seriesID, err := l.fetchSeriesID()
 	if err != nil {
 		return nil, []error{err}
 	}
 
-	page := 1
-	for {
-		uri := fmt.Sprintf(
-			"https://api.luacomic.org/chapter/query?page=%d&perPage=200&query=&order=desc&series_id=%s",
-			page,
-			seriesID,
-		)
-		body, err := http.GetText(http.RequestParams{
-			URL:     uri,
+	return walkLuascansChapters(func(page int) (string, error) {
+		return http.GetText(http.RequestParams{
+			URL: fmt.Sprintf(
+				"https://api.luacomic.org/chapter/query?page=%d&perPage=200&query=&order=desc&series_id=%s",
+				page,
+				seriesID,
+			),
 			Referer: l.URL,
 		})
+	})
+}
+
+// walkLuascansChapters requests the chapters feed page by page until the api
+// says there's nothing left. It takes the fetcher as an argument so the
+// pagination itself is testable without hitting the network.
+func walkLuascansChapters(fetchPage func(page int) (string, error)) (chapters Filterables, errs []error) {
+	// chapter slugs are unique per series, so they identify a row across
+	// pages. Two things make that necessary rather than paranoid: the feed is
+	// ordered desc, so a chapter published between two requests shifts the
+	// whole window down and re-serves rows we already have; and if the api
+	// ever stops honouring `page` while still reporting a multi-page
+	// last_page, appending blindly would repeat the same rows last_page
+	// times (which packer turns into duplicate `v2` cbz files, silently).
+	seen := map[string]bool{}
+
+	for page := 1; ; page++ {
+		body, err := fetchPage(page)
 		if err != nil {
-			errs = append(errs, err)
-			return
+			return chapters, append(errs, err)
 		}
 
 		pageChapters, feed, err := parseLuascansChaptersPage(body)
 		if err != nil {
-			errs = append(errs, err)
-			return
+			return chapters, append(errs, err)
 		}
 		// an empty page also stops the loop, in case the api ever reports a
 		// last_page beyond the actual data
 		if len(feed.Data) == 0 {
-			return
+			return chapters, errs
 		}
-		chapters = append(chapters, pageChapters...)
+
+		// fresh is computed from the raw feed rows, not from pageChapters, so
+		// that a page whose every chapter_name fails to parse still counts as
+		// progress instead of truncating the walk
+		fresh := make(map[string]bool, len(feed.Data))
+		for _, c := range feed.Data {
+			if !seen[c.Slug] {
+				seen[c.Slug] = true
+				fresh[c.Slug] = true
+			}
+		}
+		if len(fresh) == 0 {
+			return chapters, errs
+		}
+
+		for _, c := range pageChapters {
+			if fresh[c.Slug] {
+				chapters = append(chapters, c)
+			}
+		}
 
 		if page >= feed.Meta.LastPage {
-			return
+			return chapters, errs
 		}
-		page++
 	}
 }
 
@@ -107,7 +139,7 @@ func (l *Luascans) FetchChapters() (chapters Filterables, errs []error) {
 // returning the chapters it contains plus the decoded feed itself (whose
 // `meta.last_page` and raw data length tell the caller when to stop
 // paginating)
-func parseLuascansChaptersPage(body string) (chapters Filterables, feed luascansChaptersFeed, err error) {
+func parseLuascansChaptersPage(body string) (chapters []*LuascansChapter, feed luascansChaptersFeed, err error) {
 	if err = json.Unmarshal([]byte(body), &feed); err != nil {
 		return nil, feed, err
 	}

--- a/grabber/luascans.go
+++ b/grabber/luascans.go
@@ -58,10 +58,9 @@ func (l *Luascans) FetchTitle() (string, error) {
 	return l.title, nil
 }
 
-// FetchChapters returns the chapters of the manga. The API paginates (its
-// `meta` carries `last_page`), so keep requesting pages until the last one:
-// a single perPage=200 call would silently truncate the first 200+-chapter
-// series (same pattern as the qimanga & hijala grabbers).
+// FetchChapters returns the chapters of the manga, paginating via the API's
+// meta.last_page since a single perPage=200 call would silently truncate
+// series with 200+ chapters.
 func (l *Luascans) FetchChapters() (Filterables, []error) {
 	seriesID, err := l.fetchSeriesID()
 	if err != nil {
@@ -84,13 +83,10 @@ func (l *Luascans) FetchChapters() (Filterables, []error) {
 // says there's nothing left. It takes the fetcher as an argument so the
 // pagination itself is testable without hitting the network.
 func walkLuascansChapters(fetchPage func(page int) (string, error)) (chapters Filterables, errs []error) {
-	// chapter slugs are unique per series, so they identify a row across
-	// pages. Two things make that necessary rather than paranoid: the feed is
-	// ordered desc, so a chapter published between two requests shifts the
-	// whole window down and re-serves rows we already have; and if the api
-	// ever stops honouring `page` while still reporting a multi-page
-	// last_page, appending blindly would repeat the same rows last_page
-	// times (which packer turns into duplicate `v2` cbz files, silently).
+	// dedup by slug: the feed is desc-ordered, so a chapter published
+	// between requests shifts the window and re-serves rows we already
+	// have; also guards against an api that stops honouring `page`, which
+	// would otherwise repeat rows last_page times.
 	seen := map[string]bool{}
 
 	for page := 1; ; page++ {
@@ -109,9 +105,8 @@ func walkLuascansChapters(fetchPage func(page int) (string, error)) (chapters Fi
 			return chapters, errs
 		}
 
-		// fresh is computed from the raw feed rows, not from pageChapters, so
-		// that a page whose every chapter_name fails to parse still counts as
-		// progress instead of truncating the walk
+		// computed from raw feed rows, not pageChapters, so a page whose
+		// names all fail to parse still counts as progress
 		fresh := make(map[string]bool, len(feed.Data))
 		for _, c := range feed.Data {
 			if !seen[c.Slug] {
@@ -135,10 +130,8 @@ func walkLuascansChapters(fetchPage func(page int) (string, error)) (chapters Fi
 	}
 }
 
-// parseLuascansChaptersPage parses a single page of the chapters API feed,
-// returning the chapters it contains plus the decoded feed itself (whose
-// `meta.last_page` and raw data length tell the caller when to stop
-// paginating)
+// parseLuascansChaptersPage parses one page of the chapters feed, returning
+// its chapters plus the decoded feed (meta.last_page drives pagination)
 func parseLuascansChaptersPage(body string) (chapters []*LuascansChapter, feed luascansChaptersFeed, err error) {
 	if err = json.Unmarshal([]byte(body), &feed); err != nil {
 		return nil, feed, err

--- a/grabber/luascans_test.go
+++ b/grabber/luascans_test.go
@@ -29,6 +29,82 @@ func TestLuascansSeriesSlug(t *testing.T) {
 	}
 }
 
+func TestLuascansParseChaptersPage(t *testing.T) {
+	cases := []struct {
+		name         string
+		body         string
+		wantChapters []float64
+		wantLastPage int
+		wantDataLen  int
+		wantErr      bool
+	}{
+		{
+			name: "single page feed",
+			body: `{"meta":{"total":2,"per_page":200,"current_page":1,"last_page":1},` +
+				`"data":[{"chapter_name":"Chapter 2","chapter_slug":"chapter-2"},` +
+				`{"chapter_name":"Chapter 1","chapter_slug":"chapter-1"}]}`,
+			wantChapters: []float64{2, 1},
+			wantLastPage: 1,
+			wantDataLen:  2,
+		},
+		{
+			name: "intermediate page of a paginated feed",
+			body: `{"meta":{"total":250,"per_page":200,"current_page":1,"last_page":2},` +
+				`"data":[{"chapter_name":"Chapter 250","chapter_slug":"chapter-250"}]}`,
+			wantChapters: []float64{250},
+			wantLastPage: 2,
+			wantDataLen:  1,
+		},
+		{
+			name:         "empty page past the end",
+			body:         `{"meta":{"total":90,"per_page":200,"current_page":2,"last_page":1},"data":[]}`,
+			wantChapters: []float64{},
+			wantLastPage: 1,
+			wantDataLen:  0,
+		},
+		{
+			name: "unparseable chapter names are skipped but still count as data",
+			body: `{"meta":{"total":2,"per_page":200,"current_page":1,"last_page":3},` +
+				`"data":[{"chapter_name":"Special Extra","chapter_slug":"special-extra"},` +
+				`{"chapter_name":"Chapter 12.5","chapter_slug":"chapter-12-5"}]}`,
+			wantChapters: []float64{12.5},
+			wantLastPage: 3,
+			wantDataLen:  2,
+		},
+		{
+			name:    "malformed json",
+			body:    `{"meta":`,
+			wantErr: true,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			chapters, feed, err := parseLuascansChaptersPage(c.body)
+			if (err != nil) != c.wantErr {
+				t.Fatalf("parseLuascansChaptersPage() error = %v, wantErr %v", err, c.wantErr)
+			}
+			if c.wantErr {
+				return
+			}
+			if len(chapters) != len(c.wantChapters) {
+				t.Fatalf("got %d chapters, want %d", len(chapters), len(c.wantChapters))
+			}
+			for i, want := range c.wantChapters {
+				if got := chapters[i].GetNumber(); got != want {
+					t.Errorf("chapter %d number = %v, want %v", i, got, want)
+				}
+			}
+			if feed.Meta.LastPage != c.wantLastPage {
+				t.Errorf("last_page = %d, want %d", feed.Meta.LastPage, c.wantLastPage)
+			}
+			if len(feed.Data) != c.wantDataLen {
+				t.Errorf("len(feed.Data) = %d, want %d", len(feed.Data), c.wantDataLen)
+			}
+		})
+	}
+}
+
 func TestLuascansSeriesIDRe(t *testing.T) {
 	// simplified excerpt of the escaped JSON payload the series page embeds
 	// in an inline `self.__next_f.push(...)` React Server Components script

--- a/grabber/luascans_test.go
+++ b/grabber/luascans_test.go
@@ -2,7 +2,13 @@
 
 package grabber
 
-import "testing"
+import (
+	"errors"
+	"fmt"
+	"reflect"
+	"strings"
+	"testing"
+)
 
 func TestLuascansSeriesSlug(t *testing.T) {
 	cases := []struct {
@@ -100,6 +106,151 @@ func TestLuascansParseChaptersPage(t *testing.T) {
 			}
 			if len(feed.Data) != c.wantDataLen {
 				t.Errorf("len(feed.Data) = %d, want %d", len(feed.Data), c.wantDataLen)
+			}
+		})
+	}
+}
+
+// luascansFeed builds a chapters api response with the given last_page and
+// chapter slugs (named "Chapter <slug>" so they all parse)
+func luascansFeed(lastPage int, numbers ...int) string {
+	rows := make([]string, 0, len(numbers))
+	for _, n := range numbers {
+		rows = append(rows, fmt.Sprintf(
+			`{"chapter_name":"Chapter %d","chapter_slug":"chapter-%d"}`, n, n,
+		))
+	}
+	return fmt.Sprintf(
+		`{"meta":{"total":%d,"per_page":200,"last_page":%d},"data":[%s]}`,
+		len(numbers), lastPage, strings.Join(rows, ","),
+	)
+}
+
+func chapterNumbers(f Filterables) []float64 {
+	got := make([]float64, 0, len(f))
+	for _, c := range f {
+		got = append(got, c.GetNumber())
+	}
+	return got
+}
+
+func TestWalkLuascansChapters(t *testing.T) {
+	cases := []struct {
+		name string
+		// pages maps the requested page number to its response body; a page
+		// with no entry makes the fake fetcher fail the test
+		pages     map[int]string
+		fetchErr  map[int]bool
+		want      []float64
+		wantErrs  int
+		wantCalls int
+	}{
+		{
+			name:      "single page",
+			pages:     map[int]string{1: luascansFeed(1, 3, 2, 1)},
+			want:      []float64{3, 2, 1},
+			wantCalls: 1,
+		},
+		{
+			// the whole point of the fix: a single-shot fetcher would stop
+			// after page 1 and silently return a third of the series
+			name: "walks every page",
+			pages: map[int]string{
+				1: luascansFeed(3, 9, 8, 7),
+				2: luascansFeed(3, 6, 5, 4),
+				3: luascansFeed(3, 3, 2, 1),
+			},
+			want:      []float64{9, 8, 7, 6, 5, 4, 3, 2, 1},
+			wantCalls: 3,
+		},
+		{
+			name: "stops on an empty page even if last_page says otherwise",
+			pages: map[int]string{
+				1: luascansFeed(5, 2, 1),
+				2: `{"meta":{"total":2,"per_page":200,"last_page":5},"data":[]}`,
+			},
+			want:      []float64{2, 1},
+			wantCalls: 2,
+		},
+		{
+			// a desc-ordered feed shifts when a chapter is published between
+			// two requests, re-serving rows we already collected
+			name: "dedups a shifted window",
+			pages: map[int]string{
+				1: luascansFeed(2, 5, 4, 3),
+				2: luascansFeed(2, 3, 2, 1),
+			},
+			want:      []float64{5, 4, 3, 2, 1},
+			wantCalls: 2,
+		},
+		{
+			// an api that stops honouring `page` must not re-append the same
+			// rows last_page times, nor loop forever
+			name: "stops when a page makes no progress",
+			pages: map[int]string{
+				1: luascansFeed(4, 3, 2, 1),
+				2: luascansFeed(4, 3, 2, 1),
+			},
+			want:      []float64{3, 2, 1},
+			wantCalls: 2,
+		},
+		{
+			// unparseable names must not be mistaken for "no progress"
+			name: "an all-unparseable page does not truncate the walk",
+			pages: map[int]string{
+				1: luascansFeed(3, 4, 3),
+				2: `{"meta":{"total":6,"per_page":200,"last_page":3},` +
+					`"data":[{"chapter_name":"Extras","chapter_slug":"extras"},` +
+					`{"chapter_name":"Prologue","chapter_slug":"prologue"}]}`,
+				3: luascansFeed(3, 2, 1),
+			},
+			want:      []float64{4, 3, 2, 1},
+			wantCalls: 3,
+		},
+		{
+			// a failed intermediate fetch must surface, not be swallowed
+			name:      "a mid-walk fetch error surfaces",
+			pages:     map[int]string{1: luascansFeed(3, 6, 5, 4)},
+			fetchErr:  map[int]bool{2: true},
+			want:      []float64{6, 5, 4},
+			wantErrs:  1,
+			wantCalls: 2,
+		},
+		{
+			name:      "malformed json surfaces",
+			pages:     map[int]string{1: `{"meta":`},
+			wantErrs:  1,
+			wantCalls: 1,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			calls := 0
+			got, errs := walkLuascansChapters(func(page int) (string, error) {
+				calls++
+				if calls > 20 {
+					t.Fatalf("walkLuascansChapters did not terminate (page %d)", page)
+				}
+				if c.fetchErr[page] {
+					return "", errors.New("boom")
+				}
+				body, ok := c.pages[page]
+				if !ok {
+					t.Fatalf("unexpected request for page %d", page)
+				}
+				return body, nil
+			})
+
+			if len(errs) != c.wantErrs {
+				t.Fatalf("got %d errors (%v), want %d", len(errs), errs, c.wantErrs)
+			}
+			if calls != c.wantCalls {
+				t.Errorf("fetched %d pages, want %d", calls, c.wantCalls)
+			}
+			if diff := chapterNumbers(got); !reflect.DeepEqual(diff, c.want) &&
+				!(len(diff) == 0 && len(c.want) == 0) {
+				t.Errorf("chapters = %v, want %v", diff, c.want)
 			}
 		})
 	}

--- a/grabber/mangapark.go
+++ b/grabber/mangapark.go
@@ -77,14 +77,10 @@ func (m *Mangapark) FetchTitle() (string, error) {
 	return m.title, nil
 }
 
-// FetchChapters returns the chapters of the manga.
-//
-// The get-chapter-list API is single-shot by design: it takes no paging
-// params and returned complete lists in every audited case (e.g. 42/42
-// entries on a 41-chapter series), but no 500+-chapter series could be
-// verified (Cloudflare gates the whole domain and no big-series slug was
-// reachable). If truncation reports ever come in, re-check this endpoint
-// against a 500+-chapter series before assuming the list is complete.
+// FetchChapters returns the chapters of the manga. get-chapter-list takes no
+// paging params and returned complete lists in every audited case, but no
+// 500+-chapter series could be verified (Cloudflare blocks access) — re-check
+// this endpoint if truncation is ever reported.
 func (m *Mangapark) FetchChapters() (Filterables, []error) {
 	if err := m.fetchSeriesData(); err != nil {
 		return nil, []error{err}

--- a/grabber/mangapark.go
+++ b/grabber/mangapark.go
@@ -77,7 +77,14 @@ func (m *Mangapark) FetchTitle() (string, error) {
 	return m.title, nil
 }
 
-// FetchChapters returns the chapters of the manga
+// FetchChapters returns the chapters of the manga.
+//
+// The get-chapter-list API is single-shot by design: it takes no paging
+// params and returned complete lists in every audited case (e.g. 42/42
+// entries on a 41-chapter series), but no 500+-chapter series could be
+// verified (Cloudflare gates the whole domain and no big-series slug was
+// reachable). If truncation reports ever come in, re-check this endpoint
+// against a 500+-chapter series before assuming the list is complete.
 func (m *Mangapark) FetchChapters() (Filterables, []error) {
 	if err := m.fetchSeriesData(); err != nil {
 		return nil, []error{err}

--- a/grabber/plainhtml.go
+++ b/grabber/plainhtml.go
@@ -170,11 +170,10 @@ func (m *PlainHTML) Test() (bool, error) {
 		// rokaricomics.com and violetscans.org (witchscans.com used to be
 		// here too, but it rebranded to witchtoons.net on an entirely
 		// different platform, handled by the dedicated witchtoons grabber).
-		// Reader pages
-		// embed all pages in a ts_reader.run(...) blob, already handled by
-		// getPlainHTMLImageURL, so Image is just a fallback here. Some of
-		// these coin-paywall their most recent chapters (no href / no images
-		// in the HTML); test with an older, unlocked chapter. Rows requires
+		// Reader pages embed all pages in a ts_reader.run(...) blob, already
+		// handled by getPlainHTMLImageURL, so Image is just a fallback here.
+		// Some of these coin-paywall their most recent chapters (no href / no
+		// images in the HTML); test with an older, unlocked chapter. Rows requires
 		// .chapternum so a bare #chapterlist wrapper on an unrelated site
 		// (e.g. mangahere.cc) can't match this entry, and Title is scoped
 		// by itemprop because some of these (violetscans) also render

--- a/grabber/plainhtml.go
+++ b/grabber/plainhtml.go
@@ -167,17 +167,17 @@ func (m *PlainHTML) Test() (bool, error) {
 		// mangastream/themesia WordPress themes reachable over plain HTTP
 		// (same markup as the cloudflare-gated sushiscan.net in
 		// plainhtmlbrowser.go): silentquill.net, lagoonscans.com,
-		// rokaricomics.com and violetscans.org (witchscans.com used to be
-		// here too, but it rebranded to witchtoons.net on an entirely
-		// different platform, handled by the dedicated witchtoons grabber).
-		// Reader pages embed all pages in a ts_reader.run(...) blob, already
-		// handled by getPlainHTMLImageURL, so Image is just a fallback here.
-		// Some of these coin-paywall their most recent chapters (no href / no
-		// images in the HTML); test with an older, unlocked chapter. Rows requires
-		// .chapternum so a bare #chapterlist wrapper on an unrelated site
-		// (e.g. mangahere.cc) can't match this entry, and Title is scoped
-		// by itemprop because some of these (violetscans) also render
-		// decorative <h1> stat labels (Type/Status/Views).
+		// rokaricomics.com and violetscans.org (witchscans.com moved to
+		// witchtoons.net on a different platform; see the witchtoons
+		// grabber). Reader pages embed all pages in a ts_reader.run(...)
+		// blob, already handled by getPlainHTMLImageURL, so Image is just a
+		// fallback here. Some of these coin-paywall their most recent
+		// chapters (no href / no images in the HTML); test with an older,
+		// unlocked chapter. Rows requires .chapternum so a bare #chapterlist
+		// wrapper on an unrelated site (e.g. mangahere.cc) can't match this
+		// entry, and Title is scoped by itemprop because some of these
+		// (violetscans) also render decorative <h1> stat labels
+		// (Type/Status/Views).
 		{
 			Title:        `h1[itemprop="name"]`,
 			Rows:         "#chapterlist li:has(.chapternum)",

--- a/grabber/plainhtml.go
+++ b/grabber/plainhtml.go
@@ -167,7 +167,10 @@ func (m *PlainHTML) Test() (bool, error) {
 		// mangastream/themesia WordPress themes reachable over plain HTTP
 		// (same markup as the cloudflare-gated sushiscan.net in
 		// plainhtmlbrowser.go): silentquill.net, lagoonscans.com,
-		// rokaricomics.com, violetscans.org and witchscans.com. Reader pages
+		// rokaricomics.com and violetscans.org (witchscans.com used to be
+		// here too, but it rebranded to witchtoons.net on an entirely
+		// different platform, handled by the dedicated witchtoons grabber).
+		// Reader pages
 		// embed all pages in a ts_reader.run(...) blob, already handled by
 		// getPlainHTMLImageURL, so Image is just a fallback here. Some of
 		// these coin-paywall their most recent chapters (no href / no images


### PR DESCRIPTION
This is Claude (Fable 5) speaking on behalf of elboletaire.

Bundles three small near-miss hardening items flagged by the repo-wide chapter-list audit that followed #169.

## 1. fix(luascans): paginate the chapters API

`grabber/luascans.go` made a single `page=1&perPage=200` call and ignored the feed's `meta` (`total`/`last_page`/`next_page_url`) entirely, silently truncating any 200+-chapter series to its newest 200. The audit found a max of 90 chapters at the time — but **the bug is live today**: a fresh scan of series ids 1–450 on `api.luacomic.org` found *hero-killer* (id 264) at **277 chapters** (`last_page: 2` at `perPage=200`), plus surviving-as-a-tyrants-daughter (260), lady-baby (240) and several others past 200.

Now the grabber loops until `meta.last_page`, following the same pattern as the `qimanga` and `hijala` grabbers. Page parsing is extracted as a pure function (`parseLuascansChaptersPage`) with a table test covering single-page feeds, intermediate pages, empty pages, unparseable chapter names, and malformed JSON.

**Live verification:**
- `FetchChapters` on https://luacomic.org/series/hero-killer returns **277/277** chapters, matching `meta.total` (the old code would have returned 200).
- Downloaded chapter 250 (deliberately behind the newest — paywalls look like success): 28/28 pages, and the resulting CBZ passes `tools/verify-cbz`.

## 2. docs(grabber): stale witchscans comment in plainhtml.go

The themesia selector comment still listed `witchscans.com`, which rebranded to witchtoons.net on a completely different platform and is handled by the dedicated `witchtoons` grabber. Comment-only fix.

## 3. docs(grabber): mangapark get-chapter-list defensive note

The audit confirmed the API returns complete lists (42/42 entries on a 41-chapter series) but couldn't test a 500+-chapter series — Cloudflare gates the whole domain and no big-series slug was verifiable. Added a code comment on `FetchChapters` noting the endpoint is single-shot by design and should be re-checked against a 500+-chapter series if truncation reports come in. No behavior change.

## Verification

- `make test` and `go vet ./...` pass.
- luascans live check as above (277/277 chapters; chapter 250 CBZ verified).