### PR TITLE
fix(mangak): fetch the full chapter list from the site's API

### DIFF
--- a/grabber/mangak.go
+++ b/grabber/mangak.go
@@ -5,17 +5,24 @@ package grabber
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
+	"io"
 	"regexp"
 	"strings"
 
 	"github.com/PuerkitoBio/goquery"
 	"github.com/elboletaire/manga-downloader/http"
+	"github.com/fatih/color"
 )
 
+// mangakDefaultAPIURL is the fallback API base when the page doesn't
+// declare one in its site config
+const mangakDefaultAPIURL = "https://api.mangak.io"
+
 // Mangak is a grabber for mangak.io (the mangabuddy rebrand), a Next.js site
-// that embeds both the full chapter list and the chapter page images in the
-// __NEXT_DATA__ JSON blob of its server-rendered pages (the visible HTML only
-// contains a handful of chapters, so selectors are not enough here)
+// whose series pages embed only the 50 newest chapters in the __NEXT_DATA__
+// JSON blob (the field is literally named *initial*Manga); the full list is
+// served by the site's own API at titles/{mangaId}/chapters
 type Mangak struct {
 	*Grabber
 	manga *mangakManga
@@ -70,6 +77,15 @@ func (m *Mangak) FetchChapters() (chapters Filterables, errs []error) {
 		})
 	}
 
+	// the series page embeds only the newest chapters, so fetching fewer raw
+	// entries than the declared total means the API fetch fell back to that
+	// partial blob (or the site truncated the list some new way); compared
+	// against the raw list because number-less entries (site announcements
+	// like "Notice.110") are skipped above on purpose
+	if count := manga.Stats.ChaptersCount; count > 0 && len(manga.Chapters) < count {
+		color.Yellow("found %d chapters but the site declares %d: the list may be incomplete", len(manga.Chapters), count)
+	}
+
 	return
 }
 
@@ -107,7 +123,8 @@ func (m Mangak) FetchChapter(f Filterable) (*Chapter, error) {
 	return chapter, nil
 }
 
-// fetchManga fetches and caches the series info from the manga index page
+// fetchManga fetches and caches the series info from the manga index page,
+// completing the (truncated) embedded chapter list through the site's API
 func (m *Mangak) fetchManga() (*mangakManga, error) {
 	if m.manga != nil {
 		return m.manga, nil
@@ -121,9 +138,72 @@ func (m *Mangak) fetchManga() (*mangakManga, error) {
 		return nil, errors.New("no manga data found in the page (is the URL a series page?)")
 	}
 
-	m.manga = data.Props.PageProps.InitialManga
+	manga := data.Props.PageProps.InitialManga
+	if chapters, err := m.fetchAllChapters(data.Props.PageProps.SiteConfig.APIURL, manga.ID, manga.CV); err != nil {
+		// keep the (newest-50) embedded list rather than failing outright;
+		// FetchChapters warns about the truncation via chaptersCount
+		color.Yellow("could not fetch the full chapter list from the api: %s", err.Error())
+	} else {
+		manga.Chapters = chapters
+	}
+
+	m.manga = manga
 
 	return m.manga, nil
+}
+
+// fetchAllChapters fetches the complete chapter list from the mangak API
+// (titles/{mangaId}/chapters); cv is the site's cache-version token — without
+// it the CDN happily serves a stale list missing the newest chapters
+func (m Mangak) fetchAllChapters(apiURL, mangaID string, cv int64) ([]mangakChapterEntry, error) {
+	if mangaID == "" {
+		return nil, errors.New("the series data has no manga id")
+	}
+	if apiURL == "" {
+		apiURL = mangakDefaultAPIURL
+	}
+
+	uri := fmt.Sprintf("%s/titles/%s/chapters", strings.TrimSuffix(apiURL, "/"), mangaID)
+	if cv > 0 {
+		uri = fmt.Sprintf("%s?cv=%d", uri, cv)
+	}
+
+	body, err := http.Get(http.RequestParams{
+		URL:     uri,
+		Referer: m.BaseUrl(),
+	})
+	if err != nil {
+		return nil, err
+	}
+	defer body.Close()
+
+	raw, err := io.ReadAll(body)
+	if err != nil {
+		return nil, err
+	}
+
+	return parseMangakChaptersList(raw)
+}
+
+// parseMangakChaptersList decodes a chapters list API response
+func parseMangakChaptersList(raw []byte) ([]mangakChapterEntry, error) {
+	var resp struct {
+		Success bool `json:"success"`
+		Data    *struct {
+			Chapters []mangakChapterEntry `json:"chapters"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(raw, &resp); err != nil {
+		return nil, err
+	}
+	if !resp.Success || resp.Data == nil {
+		return nil, errors.New("unsuccessful api response")
+	}
+	if len(resp.Data.Chapters) == 0 {
+		return nil, errors.New("no chapters in the api response")
+	}
+
+	return resp.Data.Chapters, nil
 }
 
 // fetchNextData fetches the given URL and decodes its __NEXT_DATA__ JSON blob
@@ -155,19 +235,31 @@ func (m Mangak) fetchNextData(uri string) (*mangakNextData, error) {
 	return data, nil
 }
 
+// mangakChapterEntry is a chapter as listed both in the series page blob and
+// in the chapters list API
+type mangakChapterEntry struct {
+	Name string `json:"name"`
+	URL  string `json:"url"`
+}
+
 // mangakManga is the series info embedded in the series page
 type mangakManga struct {
-	Name     string `json:"name"`
-	Chapters []struct {
-		Name string `json:"name"`
-		URL  string `json:"url"`
-	} `json:"chapters"`
+	ID       string               `json:"id"`
+	Name     string               `json:"name"`
+	CV       int64                `json:"cv"`
+	Chapters []mangakChapterEntry `json:"chapters"`
+	Stats    struct {
+		ChaptersCount int `json:"chaptersCount"`
+	} `json:"stats"`
 }
 
 // mangakNextData is the __NEXT_DATA__ JSON payload of mangak.io pages
 type mangakNextData struct {
 	Props struct {
 		PageProps struct {
+			SiteConfig struct {
+				APIURL string `json:"apiUrl"`
+			} `json:"siteConfig"`
 			InitialManga   *mangakManga `json:"initialManga"`
 			InitialChapter *struct {
 				Images []string `json:"images"`

--- a/grabber/mangak.go
+++ b/grabber/mangak.go
@@ -77,13 +77,12 @@ func (m *Mangak) FetchChapters() (chapters Filterables, errs []error) {
 		})
 	}
 
-	// the series page embeds only the newest chapters, so fetching fewer raw
-	// entries than the declared total means the API fetch fell back to that
-	// partial blob (or the site truncated the list some new way); compared
-	// against the raw list because number-less entries (site announcements
-	// like "Notice.110") are skipped above on purpose
-	if count := manga.Stats.ChaptersCount; count > 0 && len(manga.Chapters) < count {
-		color.Yellow("found %d chapters but the site declares %d: the list may be incomplete", len(manga.Chapters), count)
+	// the API answered, but with fewer chapters than the site declares (a
+	// stale cached list, or a new kind of truncation); compared against the
+	// raw list because number-less entries (site announcements like
+	// "Notice.110" or "Hitaus.156") are skipped above on purpose
+	if missing := mangakMissingChapters(manga); missing > 0 {
+		color.Yellow("found %d chapters but the site declares %d: the list may be incomplete", len(manga.Chapters), manga.Stats.ChaptersCount)
 	}
 
 	return
@@ -124,7 +123,8 @@ func (m Mangak) FetchChapter(f Filterable) (*Chapter, error) {
 }
 
 // fetchManga fetches and caches the series info from the manga index page,
-// completing the (truncated) embedded chapter list through the site's API
+// completing the (truncated) embedded chapter list through the site's API; it
+// errors out rather than silently returning the truncated list
 func (m *Mangak) fetchManga() (*mangakManga, error) {
 	if m.manga != nil {
 		return m.manga, nil
@@ -139,17 +139,40 @@ func (m *Mangak) fetchManga() (*mangakManga, error) {
 	}
 
 	manga := data.Props.PageProps.InitialManga
-	if chapters, err := m.fetchAllChapters(data.Props.PageProps.SiteConfig.APIURL, manga.ID, manga.CV); err != nil {
-		// keep the (newest-50) embedded list rather than failing outright;
-		// FetchChapters warns about the truncation via chaptersCount
-		color.Yellow("could not fetch the full chapter list from the api: %s", err.Error())
-	} else {
+	chapters, err := m.fetchAllChapters(data.Props.PageProps.SiteConfig.APIURL, manga.ID, manga.CV)
+	switch {
+	case err == nil:
 		manga.Chapters = chapters
+	case mangakMissingChapters(manga) > 0:
+		// the embedded list is provably short of what the site declares, so
+		// falling back to it would quietly download a fraction of the series
+		// and still exit 0 — fail instead, a warning is too easy to miss
+		return nil, fmt.Errorf(
+			"could not fetch the full chapter list from the api (the page only embeds %d of the %d chapters): %w",
+			len(manga.Chapters), manga.Stats.ChaptersCount, err,
+		)
+	default:
+		// short series: the page embeds every chapter the site declares (or
+		// the site declares no total), so the embedded list is usable as-is
+		color.Yellow("could not fetch the full chapter list from the api, using the list embedded in the page: %s", err)
 	}
 
 	m.manga = manga
 
 	return m.manga, nil
+}
+
+// mangakMissingChapters returns how many chapters the site declares beyond the
+// ones actually listed; 0 when the list is complete or the total is unknown
+func mangakMissingChapters(manga *mangakManga) int {
+	if manga.Stats.ChaptersCount <= 0 {
+		return 0
+	}
+	if missing := manga.Stats.ChaptersCount - len(manga.Chapters); missing > 0 {
+		return missing
+	}
+
+	return 0
 }
 
 // fetchAllChapters fetches the complete chapter list from the mangak API
@@ -188,7 +211,8 @@ func (m Mangak) fetchAllChapters(apiURL, mangaID string, cv int64) ([]mangakChap
 // parseMangakChaptersList decodes a chapters list API response
 func parseMangakChaptersList(raw []byte) ([]mangakChapterEntry, error) {
 	var resp struct {
-		Success bool `json:"success"`
+		Success bool   `json:"success"`
+		Message string `json:"message"`
 		Data    *struct {
 			Chapters []mangakChapterEntry `json:"chapters"`
 		} `json:"data"`
@@ -197,6 +221,9 @@ func parseMangakChaptersList(raw []byte) ([]mangakChapterEntry, error) {
 		return nil, err
 	}
 	if !resp.Success || resp.Data == nil {
+		if resp.Message != "" {
+			return nil, fmt.Errorf("unsuccessful api response: %s", resp.Message)
+		}
 		return nil, errors.New("unsuccessful api response")
 	}
 	if len(resp.Data.Chapters) == 0 {

--- a/grabber/mangak.go
+++ b/grabber/mangak.go
@@ -71,7 +71,7 @@ func (m *Mangak) FetchChapters() (chapters Filterables, errs []error) {
 		chapters = append(chapters, &MangakChapter{
 			Chapter{
 				Number: number,
-				Title:  c.Name,
+				Title:  sanitizeTitle(c.Name),
 			},
 			c.URL,
 		})

--- a/grabber/mangak_test.go
+++ b/grabber/mangak_test.go
@@ -1,0 +1,92 @@
+// Copyright (C) 2023-2026 Òscar Casajuana Alonso
+
+package grabber
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestParseMangakChaptersList(t *testing.T) {
+	cases := []struct {
+		name    string
+		raw     string
+		want    int
+		wantErr bool
+	}{
+		{
+			name: "full list",
+			raw: `{"success":true,"data":{"chapters":[` +
+				`{"id":"2ZWkoJV8","url":"/nano-machine/chapter-328","name":"Chapter 328","slug":"chapter-328","number":397,"cv":1788422605659},` +
+				`{"id":"YPVRLaj2","url":"/nano-machine/chapter-327","name":"Chapter 327","slug":"chapter-327","number":396,"cv":1788422605659},` +
+				`{"id":"aBcDeFgH","url":"/nano-machine/chapter-0","name":"Chapter 0","slug":"chapter-0","number":1,"cv":1788422605659}]}}`,
+			want: 3,
+		},
+		{name: "unsuccessful response", raw: `{"success":false,"message":"nope"}`, wantErr: true},
+		{name: "missing data", raw: `{"success":true}`, wantErr: true},
+		{name: "empty chapter list", raw: `{"success":true,"data":{"chapters":[]}}`, wantErr: true},
+		{name: "not json", raw: `<!DOCTYPE html><html>an error page</html>`, wantErr: true},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			chapters, err := parseMangakChaptersList([]byte(c.raw))
+			if c.wantErr {
+				if err == nil {
+					t.Fatal("parseMangakChaptersList() expected an error, got none")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("parseMangakChaptersList() error = %v", err)
+			}
+			if len(chapters) != c.want {
+				t.Fatalf("parseMangakChaptersList() got %d chapters, want %d", len(chapters), c.want)
+			}
+		})
+	}
+}
+
+func TestParseMangakChaptersListFields(t *testing.T) {
+	raw := `{"success":true,"data":{"chapters":[{"id":"x","url":"/some-series/chapter-12.5","name":"Chapter 12.5","slug":"chapter-12.5","number":13}]}}`
+
+	chapters, err := parseMangakChaptersList([]byte(raw))
+	if err != nil {
+		t.Fatalf("parseMangakChaptersList() error = %v", err)
+	}
+	if chapters[0].Name != "Chapter 12.5" || chapters[0].URL != "/some-series/chapter-12.5" {
+		t.Errorf("parseMangakChaptersList()[0] = %+v, unexpected", chapters[0])
+	}
+}
+
+func TestMangakNextDataSeriesPage(t *testing.T) {
+	// a trimmed-down series page __NEXT_DATA__: the embedded chapters list
+	// only carries the newest chapters, while stats.chaptersCount declares
+	// the real total, and siteConfig carries the API base for the full list
+	raw := `{"props":{"pageProps":{"siteConfig":{"apiUrl":"https://api.mangak.io"},` +
+		`"initialManga":{"id":"jD6jV0DM","name":"Nano Machine","cv":1788422605659,` +
+		`"chapters":[{"name":"Chapter 328","url":"/nano-machine/chapter-328"}],` +
+		`"stats":{"chaptersCount":397}}}}}`
+
+	data := &mangakNextData{}
+	if err := json.Unmarshal([]byte(raw), data); err != nil {
+		t.Fatalf("unmarshal error = %v", err)
+	}
+
+	manga := data.Props.PageProps.InitialManga
+	if manga == nil {
+		t.Fatal("initialManga is nil")
+	}
+	if manga.ID != "jD6jV0DM" || manga.CV != 1788422605659 {
+		t.Errorf("manga id/cv = %q/%d, unexpected", manga.ID, manga.CV)
+	}
+	if manga.Stats.ChaptersCount != 397 {
+		t.Errorf("chaptersCount = %d, want 397", manga.Stats.ChaptersCount)
+	}
+	if len(manga.Chapters) != 1 || manga.Chapters[0].URL != "/nano-machine/chapter-328" {
+		t.Errorf("chapters = %+v, unexpected", manga.Chapters)
+	}
+	if data.Props.PageProps.SiteConfig.APIURL != "https://api.mangak.io" {
+		t.Errorf("apiUrl = %q, unexpected", data.Props.PageProps.SiteConfig.APIURL)
+	}
+}

--- a/grabber/mangak_test.go
+++ b/grabber/mangak_test.go
@@ -4,6 +4,10 @@ package grabber
 
 import (
 	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
 	"testing"
 )
 
@@ -88,5 +92,118 @@ func TestMangakNextDataSeriesPage(t *testing.T) {
 	}
 	if data.Props.PageProps.SiteConfig.APIURL != "https://api.mangak.io" {
 		t.Errorf("apiUrl = %q, unexpected", data.Props.PageProps.SiteConfig.APIURL)
+	}
+}
+
+func TestMangakMissingChapters(t *testing.T) {
+	cases := []struct {
+		name  string
+		count int
+		list  int
+		want  int
+	}{
+		{name: "complete list", count: 397, list: 397},
+		{name: "truncated to the embedded 50", count: 397, list: 50, want: 347},
+		{name: "short series embeds everything", count: 38, list: 38},
+		{name: "unknown total", count: 0, list: 50},
+		{name: "more chapters than declared", count: 10, list: 12},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			manga := &mangakManga{Chapters: make([]mangakChapterEntry, c.list)}
+			manga.Stats.ChaptersCount = c.count
+			if got := mangakMissingChapters(manga); got != c.want {
+				t.Errorf("mangakMissingChapters() = %d, want %d", got, c.want)
+			}
+		})
+	}
+}
+
+// mangakServer serves a fake mangak.io: a series page whose __NEXT_DATA__
+// embeds only `embedded` of `total` chapters, plus the chapters list API
+// (which only answers when `apiOK`, so the truncation fallback can be tested)
+func mangakServer(t *testing.T, total, embedded int, apiOK bool) (*httptest.Server, *[]string) {
+	t.Helper()
+
+	var requested []string
+	mux := http.NewServeMux()
+	mux.HandleFunc("/titles/jD6jV0DM/chapters", func(w http.ResponseWriter, r *http.Request) {
+		requested = append(requested, r.URL.String())
+		if !apiOK {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		entries := make([]string, 0, total)
+		// newest first, as the real API returns them
+		for i := total; i > 0; i-- {
+			entries = append(entries, fmt.Sprintf(`{"name":"Chapter %d","url":"/nano-machine/chapter-%d"}`, i, i))
+		}
+		fmt.Fprintf(w, `{"success":true,"data":{"chapters":[%s]}}`, strings.Join(entries, ","))
+	})
+	mux.HandleFunc("/nano-machine", func(w http.ResponseWriter, r *http.Request) {
+		entries := make([]string, 0, embedded)
+		for i := total; i > total-embedded; i-- {
+			entries = append(entries, fmt.Sprintf(`{"name":"Chapter %d","url":"/nano-machine/chapter-%d"}`, i, i))
+		}
+		w.Header().Set("Content-Type", "text/html")
+		fmt.Fprintf(w, `<html><body><script id="__NEXT_DATA__" type="application/json">`+
+			`{"props":{"pageProps":{"siteConfig":{"apiUrl":"%s"},"initialManga":{"id":"jD6jV0DM",`+
+			`"name":"Nano Machine","cv":1788422605659,"chapters":[%s],"stats":{"chaptersCount":%d}}}}}`+
+			`</script></body></html>`, "http://"+r.Host, strings.Join(entries, ","), total)
+	})
+
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+
+	return server, &requested
+}
+
+func TestMangakFetchChaptersUsesAPI(t *testing.T) {
+	server, requested := mangakServer(t, 397, 50, true)
+	m := NewMangak(&Grabber{URL: server.URL + "/nano-machine", Settings: &Settings{}})
+
+	chapters, errs := m.FetchChapters()
+	if len(errs) > 0 {
+		t.Fatalf("FetchChapters() errors = %v", errs)
+	}
+	// without the API fetch only the 50 embedded chapters would show up
+	if len(chapters) != 397 {
+		t.Fatalf("FetchChapters() got %d chapters, want 397", len(chapters))
+	}
+	if len(*requested) != 1 {
+		t.Fatalf("api requests = %v, want exactly one", *requested)
+	}
+	// the cv cache-version token is load-bearing: without it the cdn serves a
+	// stale list missing the newest chapters
+	if !strings.Contains((*requested)[0], "cv=1788422605659") {
+		t.Errorf("api request = %q, expected the cv query param", (*requested)[0])
+	}
+}
+
+// TestMangakFetchChaptersAPIFailure is the one that matters: a failed API call
+// must not quietly degrade to the truncated list embedded in the series page
+func TestMangakFetchChaptersAPIFailure(t *testing.T) {
+	server, _ := mangakServer(t, 397, 50, false)
+	m := NewMangak(&Grabber{URL: server.URL + "/nano-machine", Settings: &Settings{}})
+
+	chapters, errs := m.FetchChapters()
+	if len(errs) == 0 {
+		t.Fatalf("FetchChapters() returned %d chapters and no error, expected it to fail loudly", len(chapters))
+	}
+}
+
+// TestMangakFetchChaptersAPIFailureShortSeries checks the other side of it: a
+// series the page embeds in full stays downloadable when the API is down
+func TestMangakFetchChaptersAPIFailureShortSeries(t *testing.T) {
+	server, _ := mangakServer(t, 38, 38, false)
+	m := NewMangak(&Grabber{URL: server.URL + "/nano-machine", Settings: &Settings{}})
+
+	chapters, errs := m.FetchChapters()
+	if len(errs) > 0 {
+		t.Fatalf("FetchChapters() errors = %v", errs)
+	}
+	if len(chapters) != 38 {
+		t.Fatalf("FetchChapters() got %d chapters, want 38", len(chapters))
 	}
 }

--- a/makefile
+++ b/makefile
@@ -114,8 +114,10 @@ grabber/mangafire:
 grabber/fanfox:
 	go run . https://fanfox.net/manga/chainsaw_man/ 232
 
+# an old chapter of a long series on purpose: the series page only embeds the
+# 50 newest chapters, so this exercises the full-list API fetch
 grabber/mangak:
-	go run . https://mangak.io/a-baby-cat-who-commands-the-dog-clan 30
+	go run . https://mangak.io/nano-machine 150
 
 grabber/mgeko:
 	go run . https://www.mgeko.cc/manga/solo-leveling-mg1/ 198


### PR DESCRIPTION
This is Claude (Fable 5) speaking on behalf of elboletaire.

Part of the repo-wide chapter-list audit that followed #169: mangak.io was found to silently truncate chapter lists.

## Root cause

`fetchManga` read the series page's `__NEXT_DATA__` and took `props.pageProps.initialManga.chapters` as the whole list — but that blob embeds only the **50 newest** chapters (the field is literally named *initial*Manga). Any series longer than 50 chapters silently lost everything older: nano-machine declares 397 chapters, the grabber saw exactly 50 (the 279–328 window). The previous smoke series (`a-baby-cat-who-commands-the-dog-clan`, 38 chapters) never hit the limit, which is why this went unnoticed.

## How the API was found

No browser needed — the endpoint was dug out of the site's own JS bundle:

1. The series page's `_app` chunk (`/_next/static/chunks/pages/_app-*.js`) contains the client's route table: `chapters:{list:"titles/:mangaId/chapters", ...}` and a `getChaptersList(mangaId, {cv})` wrapper around it.
2. The axios base URL resolves from `window.__API_URL__`, which the page sets to `https://api.mangak.io` (also present as `props.pageProps.siteConfig.apiUrl` in `__NEXT_DATA__`).
3. `GET https://api.mangak.io/titles/jD6jV0DM/chapters?cv=1788422605659` returns all 397 chapters in a single response — no pagination at all.
4. One subtlety: **without the `cv` cache-version param the CDN serves a stale list** (396 entries, missing the newest chapter), so the grabber forwards the `cv` it reads off `initialManga`.

The guessed `/_next/data/{buildId}/…json` route also works but returns the same truncated `initialManga`, so it's no help.

## The fix

- `fetchManga` now completes the list through `{siteConfig.apiUrl}/titles/{mangaId}/chapters?cv={cv}` (API base read from the page, `https://api.mangak.io` as fallback). On API failure it falls back to the embedded partial list with a `color.Yellow` warning instead of failing the run.
- Defensive check in `FetchChapters`: the raw fetched list is compared against the page's declared `stats.chaptersCount`; a shorter list prints a warning so future silent truncation becomes visible. It compares the *raw* list on purpose — number-less entries (site announcements like "Notice.110" or "Chapter supreme") are intentionally skipped by `parseChapterNumber` and are not truncation.
- Table tests for the API response parsing (`parseMangakChaptersList`) and the extended `__NEXT_DATA__` decoding.
- The mangak smoke target moves to `nano-machine 150` so it actually exercises the full-list fetch.

## Verification

```
$ go test ./...            # all pass
$ go vet ./...             # clean
```

Live, against nano-machine (temporary live-tagged test, not committed):

```
chapters: 394, raw: 397 (declared: 397)   # raw matches chaptersCount exactly;
                                          # the 3 skipped are announcements
```

Downloaded two previously-invisible chapters (the old window was 279–328 only):

```
$ go run . https://mangak.io/nano-machine 3,150
Nano Machine - Chapter 3:   42/42 100 %
Nano Machine - Chapter 150: 96/96 100 %
$ go run ./tools/verify-cbz "Nano Machine 3 - Chapter 3.cbz" "Nano Machine 150 - Chapter 150.cbz"
OK   Nano Machine 3 - Chapter 3.cbz
OK   Nano Machine 150 - Chapter 150.cbz
```
