### PR TITLE
fix(cmd): make --version an alias of the version command

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -60,12 +60,24 @@ It would also download chapters 10 to 20 of Black Clover from mangadex.org in Sp
 Note arguments aren't really positional, you can specify them in any order:
 
   manga-downloader --language es 10-20 https://mangadex.org/title/e7eabe96-aa17-476f-b431-2497d5e9d060/black-clover --bundle`),
-	Args: cobra.MinimumNArgs(1),
-	Run:  Run,
+	Args: func(cmd *cobra.Command, args []string) error {
+		if v, _ := cmd.Flags().GetBool("version"); v {
+			return nil
+		}
+		return cobra.MinimumNArgs(1)(cmd, args)
+	},
+	Run: Run,
 }
 
 // Run is the main function of the root command, the main downloading cmd
 func Run(cmd *cobra.Command, args []string) {
+	// `--version` is what the bug-report template asks for; honor it as an
+	// alias of the `version` command so both produce identical output
+	if v, _ := cmd.Flags().GetBool("version"); v {
+		showVersion()
+		return
+	}
+
 	// ensure the shared Chrome process (if any) is killed on exit
 	defer browser.Close()
 	browser.SetVisible(settings.BrowserVisible)
@@ -397,6 +409,7 @@ func init() {
 	rootCmd.Flags().StringVar(&settings.ConvertImages, "convert-images", grabber.ConvertImagesDefault, `comma-separated source image formats to convert to jpeg for e-reader compatibility: "avif", "webp" or "none"`)
 	rootCmd.Flags().BoolVar(&settings.BrowserVisible, "browser-visible", false, "open the browser window from the start (it opens automatically anyway when a headless attempt hits a challenge)")
 	rootCmd.Flags().Uint8VarP(&settings.Retry, "retry", "r", 1, "number of retries for failed page downloads, hard-limited to 3 (0 disables retrying)")
+	rootCmd.Flags().BoolP("version", "v", false, "show version information (alias of the version command)")
 	// set as persistent, so version command does not complain about the -o flag set via docker
 	rootCmd.PersistentFlags().StringVarP(&settings.OutputDir, "output-dir", "o", "./", "output directory for the downloaded files")
 }

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -22,37 +22,41 @@ var versionCmd = &cobra.Command{
 	Use:   "version",
 	Short: "Shows the version of the application",
 	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Printf("%s - Manga volumes downloading tool\n", color.YellowString("Manga Downloader"))
-		fmt.Printf("All Rights Reserved © 2023-2026 %s\n", color.HiBlackString("Òscar Casajuana Alonso"))
-		fmt.Printf("Version: %s - ", color.MagentaString("%s (%s)", Version, Tag))
-
-		vcheck := &latest.GithubTag{
-			Owner:             "elboletaire",
-			Repository:        "manga-downloader",
-			FixVersionStrFunc: latest.DeleteFrontV(),
-		}
-
-		res, err := latest.Check(vcheck, Tag)
-		if err != nil {
-			fmt.Printf("Error checking for updates: %s\n", err)
-			return
-		}
-		if res.Outdated {
-			fmt.Printf(
-				"%s Download latest (%s) from:\n%s\n",
-				color.HiRedString("App is outdated."),
-				color.RedString(res.Current),
-				"https://github.com/elboletaire/manga-downloader/releases/tag/v"+res.Current,
-			)
-		} else {
-			fmt.Printf("%s\n", color.GreenString("App is up to date."))
-		}
+		showVersion()
 	},
 }
 
+// showVersion prints the current version and checks GitHub for a newer
+// release. Shared by `version` and the root `--version` flag so both
+// produce identical output.
+func showVersion() {
+	fmt.Printf("%s - Manga volumes downloading tool\n", color.YellowString("Manga Downloader"))
+	fmt.Printf("All Rights Reserved © 2023-2026 %s\n", color.HiBlackString("Òscar Casajuana Alonso"))
+	fmt.Printf("Version: %s - ", color.MagentaString("%s (%s)", Version, Tag))
+
+	vcheck := &latest.GithubTag{
+		Owner:             "elboletaire",
+		Repository:        "manga-downloader",
+		FixVersionStrFunc: latest.DeleteFrontV(),
+	}
+
+	res, err := latest.Check(vcheck, Tag)
+	if err != nil {
+		fmt.Printf("Error checking for updates: %s\n", err)
+		return
+	}
+	if res.Outdated {
+		fmt.Printf(
+			"%s Download latest (%s) from:\n%s\n",
+			color.HiRedString("App is outdated."),
+			color.RedString(res.Current),
+			"https://github.com/elboletaire/manga-downloader/releases/tag/v"+res.Current,
+		)
+	} else {
+		fmt.Printf("%s\n", color.GreenString("App is up to date."))
+	}
+}
+
 func init() {
-	// also honor `manga-downloader --version` (what the bug-report template
-	// asks for); cobra handles the flag before requiring the URL argument
-	rootCmd.Version = fmt.Sprintf("%s (%s)", Version, Tag)
 	rootCmd.AddCommand(versionCmd)
 }


### PR DESCRIPTION
Sonnet 5 here, controlled by elboletaire.

## Summary
- `manga-downloader --version` (cobra's automatic version flag) and `manga-downloader version` printed different output — the former just `name (tag)`, the latter a banner plus a GitHub update check.
- Replaced the automatic `rootCmd.Version` flag with a plain `--version`/`-v` bool flag handled in `Run`, sharing the extracted `showVersion()` helper with the `version` command, so both now print identical output.
- `--version`/`-v` still bypasses the "requires at least 1 arg" validation, same as before.

## Test plan
- [x] `go build ./...`
- [x] `go test ./...`
- [x] Manually compared `--version`, `-v`, and `version` output — identical
- [x] Confirmed `manga-downloader` with no args still shows the usage error