### PR TITLE
fix(grabber): mangahub, mkissa, drakecomic

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ MangaDex, MangaFire or MangaPark to individual scanlation groups:
 - [deathtollscans.net](https://reader.deathtollscans.net)
 - [demonicscans.org (MangaDemon / Demonic Scans)](https://demonicscans.org)
 - [dragontea.ink](https://dragontea.ink) \*
-- [drakecomic.org (Drake Scans)](https://drakecomic.org) \*
+- [drakecomic.net (Drake Scans, former drakecomic.org)](https://drakecomic.net)
 - [dynasty-scans.com (Dynasty Reader)](https://dynasty-scans.com)
 - [elftoon.com](https://elftoon.com)
 - [en-hijala.com (Hijala Translations)](https://en-hijala.com)

--- a/browser/browser.go
+++ b/browser/browser.go
@@ -212,14 +212,23 @@ func GetHTMLWithScroll(url, waitSelector string, scrollIterations int, scrollPau
 	return getHTML(url, "", timeout, pre)
 }
 
+// dismissModalJS closes an open modal dialog (e.g. mkissa's "Sign in to
+// recommend this to the community rail" nag) before it eats a click. The
+// dialog's fixed, full-viewport `.modal-backdrop` sits above everything else
+// (z-index 300), so a click aimed at whatever's underneath silently lands on
+// the backdrop instead — the target element never reports being interacted
+// with, and no error is raised. A no-op when no modal is open.
+const dismissModalJS = `(function(){var c=document.querySelector('.modal-backdrop .modal__close');if(c)c.click();})()`
+
 // GetReaderHTML renders a chapter reader page for SPA sites whose reader
 // route is blocked by Cloudflare on direct navigation (confirmed via a 403
 // even after warming up cookies from the series page in the same browser
 // context) but reachable through the app's own client-side routing
-// (mkissa.to). It navigates to seriesURL, clicks tabSelector to reveal the
-// chapter list, clicks through paginationSelector buttons (if present) until
-// an element matching linkSelector appears, clicks it, then scrolls the page
-// repeatedly to force lazy-loaded reader images to resolve.
+// (mkissa.to). It navigates to seriesURL, dismisses any open sign-in modal
+// (see dismissModalJS), clicks tabSelector to reveal the chapter list,
+// clicks through paginationSelector buttons (if present) until an element
+// matching linkSelector appears, clicks it, then scrolls the page repeatedly
+// to force lazy-loaded reader images to resolve.
 //
 // Some of these readers auto-continue into the next chapter once the current
 // one is scrolled past (its pages get appended to the same DOM), so instead
@@ -258,10 +267,32 @@ func GetReaderHTML(seriesURL, tabSelector, paginationSelector, linkSelector, img
 		chromedp.Navigate(seriesURL),
 		chromedp.WaitVisible("body", chromedp.ByQuery),
 		chromedp.Sleep(2*time.Second),
-		chromedp.Click(tabSelector, chromedp.ByQuery),
-		chromedp.Sleep(time.Second),
 	); err != nil {
 		return "", fmt.Errorf("opening chapter list: %w", err)
+	}
+
+	// the sign-in nag (see dismissModalJS) pops up on a timer independent of
+	// our clicks, so it can appear between the dismiss check and the actual
+	// click landing; retry a couple of times rather than dismissing once
+	tabSelectedJS := fmt.Sprintf(`(function(){var e=document.querySelector(%q);return !!e&&e.getAttribute('aria-selected')==='true';})()`, tabSelector)
+	for attempt := 0; attempt < 3; attempt++ {
+		if err := chromedp.Run(ctx,
+			chromedp.Evaluate(dismissModalJS, nil),
+			chromedp.Click(tabSelector, chromedp.ByQuery),
+			chromedp.Sleep(time.Second),
+		); err != nil {
+			return "", fmt.Errorf("opening chapter list: %w", err)
+		}
+		var selected bool
+		if err := chromedp.Run(ctx, chromedp.Evaluate(tabSelectedJS, &selected)); err != nil {
+			return "", fmt.Errorf("opening chapter list: %w", err)
+		}
+		if selected {
+			break
+		}
+		if attempt == 2 {
+			return "", fmt.Errorf("opening chapter list: chapters tab never became selected")
+		}
 	}
 
 	// click through pagination pages until the target chapter link shows up
@@ -291,6 +322,7 @@ func GetReaderHTML(seriesURL, tabSelector, paginationSelector, linkSelector, img
 	}
 
 	if err := chromedp.Run(ctx,
+		chromedp.Evaluate(dismissModalJS, nil),
 		chromedp.Click(linkSelector, chromedp.ByQuery),
 		chromedp.Sleep(1500*time.Millisecond),
 	); err != nil {

--- a/grabber/drakecomic.go
+++ b/grabber/drakecomic.go
@@ -1,0 +1,59 @@
+// Copyright (C) 2023-2026 Òscar Casajuana Alonso
+
+package grabber
+
+import (
+	"net/url"
+	"regexp"
+	"strings"
+)
+
+// Drakecomic is a grabber for drakecomic.net (Drake Scans). It used to be a
+// themesia wordpress theme on drakecomic.org, behind a cloudflare challenge
+// (shared BrowserSiteSelector entry with sushiscan.net in
+// plainhtmlbrowser.go). The site has since moved wholesale to drakecomic.net,
+// running the same server-rendered Next.js RSC comic platform implemented in
+// rsccomic.go (shared with witchtoons.net and kaynscans.com) — plain HTTP
+// gets both the chapter list and the reader pages out of the flight payload,
+// no browser needed.
+//
+// drakecomic.org still 301s /manga/{slug}/ to
+// https://drakecomic.net/series/comic/{slug}/; Test() applies the same
+// rewrite in code so every URL the grabber builds targets the live domain
+// directly. Unlike witchtoons.net's old domain, this redirect only covers
+// the exact /manga/{slug}/ shape — any other .org path (e.g. a reconstructed
+// chapter URL) 301s to the bare drakecomic.net homepage instead, which is
+// why chapter URLs must always be built from the rewritten domain rather
+// than resolved against the original .org URL.
+type Drakecomic struct {
+	rscComic
+}
+
+func NewDrakecomic(g *Grabber) *Drakecomic {
+	return &Drakecomic{rscComic{Grabber: g}}
+}
+
+// Test returns true if the URL is a drakecomic.net URL, rewriting old
+// drakecomic.org URLs to the new domain and path shape first.
+func (d *Drakecomic) Test() (bool, error) {
+	if regexp.MustCompile(`drakecomic\.net`).MatchString(d.URL) {
+		return true, nil
+	}
+
+	if !regexp.MustCompile(`drakecomic\.org`).MatchString(d.URL) {
+		return false, nil
+	}
+
+	uri, err := url.Parse(d.URL)
+	if err != nil {
+		return false, err
+	}
+	uri.Scheme = "https"
+	uri.Host = "drakecomic.net"
+	if strings.HasPrefix(uri.Path, "/manga/") {
+		uri.Path = "/series/comic/" + strings.TrimPrefix(uri.Path, "/manga/")
+	}
+	d.URL = uri.String()
+
+	return true, nil
+}

--- a/grabber/drakecomic_test.go
+++ b/grabber/drakecomic_test.go
@@ -1,0 +1,51 @@
+// Copyright (C) 2023-2026 Òscar Casajuana Alonso
+
+package grabber
+
+import "testing"
+
+func TestDrakecomicTest(t *testing.T) {
+	cases := []struct {
+		url     string
+		want    bool
+		wantURL string // rewritten URL after Test(); empty means unchanged
+	}{
+		{"https://drakecomic.net/series/comic/beast-evolution", true, ""},
+		{"https://drakecomic.net/series/comic/beast-evolution/chapter/70", true, ""},
+		// the old domain 301s /manga/{slug}/ to
+		// drakecomic.net/series/comic/{slug}/; Test() applies the same
+		// rewrite in code
+		{
+			"https://drakecomic.org/manga/beast-evolution/",
+			true,
+			"https://drakecomic.net/series/comic/beast-evolution/",
+		},
+		{
+			"http://drakecomic.org/manga/beast-evolution",
+			true,
+			"https://drakecomic.net/series/comic/beast-evolution",
+		},
+		{"https://drakecomic.org/", true, "https://drakecomic.net/"},
+		{"https://example.com/series/comic/whatever", false, ""},
+	}
+
+	for _, c := range cases {
+		d := NewDrakecomic(&Grabber{URL: c.url})
+		got, err := d.Test()
+		if err != nil {
+			t.Errorf("Test(%q) error = %v", c.url, err)
+			continue
+		}
+		if got != c.want {
+			t.Errorf("Test(%q) = %v, want %v", c.url, got, c.want)
+			continue
+		}
+		wantURL := c.wantURL
+		if wantURL == "" {
+			wantURL = c.url
+		}
+		if d.URL != wantURL {
+			t.Errorf("Test(%q) rewrote URL to %q, want %q", c.url, d.URL, wantURL)
+		}
+	}
+}

--- a/grabber/mkissa.go
+++ b/grabber/mkissa.go
@@ -72,8 +72,11 @@ func (m *Mkissa) mangaId() (string, error) {
 const mkissaAPI = "https://api.mkissa.net/api"
 
 // mkissaInfoQueryHash is the persisted query hash for the manga info query
-// (series title + full per-translation chapter number list)
-const mkissaInfoQueryHash = "f2678aedf3d265af9ba482e9a20285aa2cfecfd55233fd2643971c2f658784bd"
+// (series title + full per-translation chapter number list). This rotates
+// occasionally along with the required variable set (see fetchInfo) — if
+// FetchChapters starts failing again, re-probe the series page with
+// PROBE_NETLOG=1 and grep for api.mkissa.net to pick up the new hash/shape.
+const mkissaInfoQueryHash = "ce7c62eed9417724f6568c38bba87a0a500f35f3cbf72b444f202df52a6d0820"
 
 // mkissaMangaInfo is the relevant subset of the manga info API response
 type mkissaMangaInfo struct {
@@ -95,7 +98,7 @@ func (m *Mkissa) fetchInfo() (*mkissaMangaInfo, error) {
 		return nil, err
 	}
 
-	variables := fmt.Sprintf(`{"_id":%q,"search":{"allowAdult":false,"allowUnknown":false}}`, id)
+	variables := fmt.Sprintf(`{"_id":%q,"search":{"allowAdult":false,"allowUnknown":false,"denyEcchi":false,"lite":false,"forMe":false}}`, id)
 	extensions := fmt.Sprintf(`{"persistedQuery":{"version":1,"sha256Hash":%q}}`, mkissaInfoQueryHash)
 
 	q := url.Values{}

--- a/grabber/plainhtmlbrowser.go
+++ b/grabber/plainhtmlbrowser.go
@@ -109,13 +109,23 @@ var browserSelectors = []BrowserSiteSelector{
 	// referer, no cookies needed. Chapter rows use CSS-module-hashed class
 	// names (subject to change on redeploys), so we key off the stable
 	// Bootstrap "list-group-item" class instead and pull the chapter number
-	// straight out of the whole row's text (it contains "#1188").
+	// straight out of the row's text (it contains "#1188"). Each row
+	// actually holds TWO (sometimes three) anchors pointing at the same
+	// chapter: the real slug-based link, plus one-or-more duplicate
+	// "title=Chapter" links (an internal numeric-id URL, order relative to
+	// the real link isn't stable) that appear to be a hover/prefetch
+	// artifact. Both/all render identical text, so an untargeted Chapter
+	// selector (or none, falling back to the whole row) concatenates them
+	// into a doubled title. The duplicates are the only anchors carrying a
+	// title attribute, so ":not([title])" reliably isolates the real one.
 	{
 		SiteSelector: SiteSelector{
-			Title: "h1",
-			Rows:  "li.list-group-item",
-			Link:  `a[href*="/chapter/"]`,
-			Image: "img.PB0mN",
+			Title:        "h1",
+			Rows:         "li.list-group-item",
+			Chapter:      "a:not([title])",
+			ChapterTitle: "a:not([title])",
+			Link:         "a:not([title])",
+			Image:        "img.PB0mN",
 		},
 		Domains:      []string{"mangahub.io"},
 		ChaptersWait: "li.list-group-item",

--- a/grabber/plainhtmlbrowser.go
+++ b/grabber/plainhtmlbrowser.go
@@ -83,13 +83,14 @@ var browserSelectors = []BrowserSiteSelector{
 		ChaptersWait: `a[href*="/reader/"]`,
 		ImageWait:    `img[alt^="Page"]`,
 	},
-	// sushiscan.net (french) and drakecomic.org (Drake Scans): mangastream/
-	// themesia theme behind a cloudflare challenge, usually needs
-	// --browser-visible. All the reader pages come from the embedded
-	// ts_reader javascript call. drakecomic.org's initial render is an
-	// (almost) empty body — #chapterlist is filled a few seconds later by
-	// an admin-ajax.php call — but WaitVisible already polls for the wait
-	// selector, so no extra settle is needed.
+	// sushiscan.net (french): mangastream/themesia theme behind a
+	// cloudflare challenge, usually needs --browser-visible. All the reader
+	// pages come from the embedded ts_reader javascript call.
+	//
+	// drakecomic.org (Drake Scans) used to share this entry too, but the
+	// site moved wholesale to a plain-HTTP Next.js RSC platform on
+	// drakecomic.net (see drakecomic.go) — #chapterlist et al no longer
+	// exist there.
 	{
 		SiteSelector: SiteSelector{
 			Title:        "h1.entry-title",
@@ -99,7 +100,7 @@ var browserSelectors = []BrowserSiteSelector{
 			Link:         "a",
 			Image:        "#readerarea img",
 		},
-		Domains:      []string{"sushiscan.net", "drakecomic.org"},
+		Domains:      []string{"sushiscan.net"},
 		ChaptersWait: "#chapterlist li",
 		ImageWait:    "#readerarea img",
 	},

--- a/grabber/plainhtmlbrowser_test.go
+++ b/grabber/plainhtmlbrowser_test.go
@@ -14,10 +14,9 @@ func TestMatchBrowserSelector(t *testing.T) {
 		{"dragontea.ink", true},
 		{"kappabeast.com", true},
 		{"sushiscan.net", true},
-		{"drakecomic.org", true},
-		{"www.drakecomic.org", true}, // www. prefix is stripped
-		{"mangakakalot.gg", false},   // handled by the Manganelo grabber
-		{"natomanga.com", false},     // handled by the Manganelo grabber
+		{"drakecomic.org", false},  // handled by the Drakecomic grabber
+		{"mangakakalot.gg", false}, // handled by the Manganelo grabber
+		{"natomanga.com", false},   // handled by the Manganelo grabber
 		{"manhuaus.com", true},
 		{"toonily.com", true},
 		{"www.toonily.com", true}, // www. prefix is stripped

--- a/grabber/site.go
+++ b/grabber/site.go
@@ -109,6 +109,7 @@ func (g *Grabber) IdentifySite() (Site, []error) {
 		NewAtsumaru(g),
 		NewVortexscans(g),
 		NewBigsolo(g),
+		NewDrakecomic(g),
 		NewFmteam(g),
 		NewGenzToon(g),
 		NewHivetoons(g),

--- a/makefile
+++ b/makefile
@@ -50,6 +50,7 @@ grabber: \
 	grabber/bluesolo \
 	grabber/comix \
 	grabber/danke \
+	grabber/drakecomic \
 	grabber/fanfox \
 	grabber/flamecomics \
 	grabber/fmteam \
@@ -232,6 +233,11 @@ grabber/fmteam:
 # pick a chapter a bit behind the tip if this starts 404ing on pages
 grabber/genztoon:
 	go run . https://genzupdates.com/series/the-return-of-the-legendary-genius-ranker/ 33
+# drakecomic.org moved wholesale to drakecomic.net (same RSC platform as
+# witchtoons.net/kaynscans.com); the old domain still 301s /manga/{slug}/
+# here and the grabber remaps old URLs in code. No browser needed anymore.
+grabber/drakecomic:
+	go run . https://drakecomic.net/series/comic/beast-evolution 70
 # kaynscan.org moved to kaynscans.com (same RSC platform as witchtoons.net);
 # the old domain still 301s here and the grabber remaps old URLs in code
 grabber/kaynscan:
@@ -274,7 +280,6 @@ grabber/mkissa:
 # (cloudflare). Run them one by one and solve the challenge if prompted.
 grabber/browser: \
 	grabber/dragontea \
-	grabber/drakecomic \
 	grabber/kappabeast \
 	grabber/mangahub \
 	grabber/mangakakalot \
@@ -321,8 +326,6 @@ grabber/mangahub:
 	go run . --browser-visible https://mangahub.io/manga/one-piece_142 1188
 grabber/manhuatop:
 	go run . --browser-visible https://manhuatop.org/manhua/chronicles-of-the-martial-gods-return/ 168
-grabber/drakecomic:
-	go run . --browser-visible https://drakecomic.org/manga/beast-evolution/ 70
 grabber/setsuscans:
 	go run . --browser-visible https://setsuscans.com/manga/a-story-about-accidentally-finding-out-a-girls-secret-at-school/ 13
 


### PR DESCRIPTION
Sonnet 5 here, controlled by elboletaire.

Fixes three grabbers that failed a live smoke-test pass:

- **mangahub**: chapter titles were coming out doubled/mangled (e.g. `#1188 - Chapter 1188; Wailing Void#1188 - Chapter 1188; Wailing Void`). Each row has a hidden duplicate `<a title="Chapter">` anchor alongside the real slug-based link, and the `BrowserSiteSelector` entry had no `Chapter`/`ChapterTitle` selector, so `FetchChapters` fell back to the whole row's `.Text()` and concatenated both. Scoped to `a:not([title])`, the only anchor without the duplicate's `title` attribute.
- **mkissa**: "No chapters found". mkissa.to rotated the Apollo persisted-query hash for its manga-info GraphQL query and now requires extra search variables (`denyEcchi`, `lite`, `forMe`); the old hash answered `PersistedQueryNotFound`. Also fixed a second bug found while verifying: `GetReaderHTML`'s clicks were being intercepted by a new "sign in to recommend this to the community rail" modal backdrop that pops up on its own timer, silently swallowing the click on the Chapters tab.
- **drakecomic**: timed out waiting for `#chapterlist li`. Not a stale selector — the site moved wholesale from `drakecomic.org` to `drakecomic.net`, replacing the old themesia/WordPress theme with the same server-rendered Next.js RSC platform already used by witchtoons.net/kaynscans.com. Added a dedicated `Drakecomic` grabber (mirroring the existing kaynscan/witchtoons precedent) that rewrites old `.org` URLs the way the site's own redirect does; no browser needed anymore.

Each fix was verified with a live `make grabber/<target>` run plus `tools/verify-cbz` on the resulting archive.

Two other failures from the same smoke-test run turned out not to be code bugs, so no changes were made for them:
- **mangitto**: `mangtto.com` returns a hard Cloudflare WAF block from this environment's egress IP (confirmed via curl and a real headless-Chromium probe, both blocked identically) — looks IP/ASN-level, not a solvable JS challenge.
- **mangalivre**: didn't reproduce — was a transient 503, a fresh run now succeeds cleanly.

`dragontea`'s failure in the same run was a known ISP-level IP ban on the tester's own network, unrelated to code, and isn't touched here.

**baozimh**'s CDN-connection-refused failure is being investigated separately and will follow as its own PR, since it needs the original grabber author's input before merging.

## Test plan
- [x] `go build ./...`, `go vet ./...`, `go test ./...` all pass
- [x] `make grabber/mangahub` → clean, non-doubled title; `verify-cbz` OK
- [x] `make grabber/mkissa` → chapters found, chapter downloaded; `verify-cbz` OK
- [x] `make grabber/drakecomic` (both old `.org` and new `.net` URLs) → `verify-cbz` OK
- [x] `make grabber/sushiscan` spot-checked unaffected by the shared-selector-entry change