### PR TITLE
fix(grabber): resolve baozimh's placeholder CDN host to a live edge

### DIFF
--- a/grabber/baozimh.go
+++ b/grabber/baozimh.go
@@ -5,11 +5,13 @@ package grabber
 import (
 	"errors"
 	"fmt"
+	nethttp "net/http"
 	"net/url"
 	"regexp"
 	"strconv"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/PuerkitoBio/goquery"
 	"github.com/elboletaire/manga-downloader/http"
@@ -18,8 +20,11 @@ import (
 
 // Baozimh is a grabber for baozimh.com (包子漫画). The series page is plain
 // server-rendered HTML listing every chapter, and the reader page embeds every
-// page as an <amp-img id="chapter-img-N-M" src=...> with a real CDN URL - no
-// browser, no pagination, no javascript needed.
+// page as an <amp-img id="chapter-img-N-M" src=...> - no browser, no
+// pagination, no javascript needed to find the pages. The embedded URL's
+// host is a placeholder, though (see resolveBzcdnHost): the reader's own JS
+// normally swaps it for a live regional edge on page load, so FetchChapter
+// does that resolution itself before returning page URLs.
 //
 // The site geo-routes its visitors: mainland-China IPs get simplified-script
 // pages (from www.baozimh.com, via a 301, on cn.bzmgcn.com) while everyone
@@ -44,6 +49,11 @@ type Baozimh struct {
 	docOnce sync.Once
 	doc     *goquery.Document
 	docErr  error
+	// cdnSuffixOnce/cdnSuffix cache the outcome of resolveBzcdnHost's probe
+	// for the lifetime of this Baozimh instance (one download run), so only
+	// the first bare-CDN image URL triggers a round of probing.
+	cdnSuffixOnce sync.Once
+	cdnSuffix     string
 }
 
 func NewBaozimh(g *Grabber) *Baozimh {
@@ -247,6 +257,7 @@ func (m *Baozimh) FetchChapter(f Filterable) (*Chapter, error) {
 				color.Yellow("page %d of %s has no URL to fetch from 😕 (will be ignored)", len(pages)+1, f.GetTitle())
 				return
 			}
+			img = m.resolveBzcdnHost(img)
 			if seen[img] {
 				// already collected from a previous part's overlap
 				return
@@ -284,6 +295,95 @@ func (m *Baozimh) FetchChapter(f Filterable) (*Chapter, error) {
 		Language:   "zh",
 		Pages:      pages,
 	}, nil
+}
+
+// bzcdnBareHostRe matches an unresolved baozimh image CDN host such as
+// "s2.bzcdn.net" - the literal hostname the reader HTML embeds in every
+// <amp-img src>. See bzcdnRegionSuffixes for why that host alone is dead.
+var bzcdnBareHostRe = regexp.MustCompile(`^(s\d+)\.bzcdn\.net$`)
+
+// bzcdnRegionSuffixes are live regional CDN edges for baozimh images,
+// e.g. "s2" + "-rsa1-usla.bzcdn.net" = "s2-rsa1-usla.bzcdn.net". The
+// bare "sN.bzcdn.net" host embedded in reader HTML is never meant to be
+// fetched directly: the site's own reader JS (choose_cdn() in
+// page_runtime_v5.js) races several regional edges behind it on page load
+// and rewrites every <amp-img src> to whichever answers first, entirely
+// client-side. A scraper that never runs that JS is left with the bare
+// host, which (as of #182) resolves to a single origin that outright
+// refuses every connection - not a dead mirror to retry, a placeholder
+// that was never meant to be requested as-is.
+//
+// This list was extracted by running the site's own obfuscated JS
+// (REQ_DOMAINS in page_runtime_v5.js, one entry deobfuscated via a decode
+// function it exports) rather than guessed, and is ordered the same way:
+// the three edges the site itself weights highest (and independently
+// confirmed live - '-rsa1-usla' first, since that's the one seen actually
+// serving images in a live browser) before its lower-priority Hong Kong
+// edge. If baozimh rotates its edges again, re-probe with PROBE_NETLOG=1
+// or by fetching page_runtime_v5.js fresh and decoding REQ_DOMAINS the
+// same way.
+var bzcdnRegionSuffixes = []string{
+	"-rsa1-usla.bzcdn.net",
+	"-ogsm1-uspho.bzcdn.net",
+	"-mha1-nlams.bzcdn.net",
+	"-dpa1-cnhk.bzcdn.net",
+}
+
+// bzcdnProbeClient is dedicated to resolveBzcdnHost's candidate checks. It
+// carries its own short timeout so a candidate that hangs (rather than
+// failing fast like a refused connection) can't stall a chapter download;
+// the shared http package's client has no timeout, since normal page/image
+// downloads may legitimately be slow.
+var bzcdnProbeClient = &nethttp.Client{Timeout: 5 * time.Second}
+
+// bzcdnProbe reports whether url answers with 200 OK. A var (not a plain
+// function) so tests can substitute a fake without touching the network.
+var bzcdnProbe = func(url string) bool {
+	resp, err := bzcdnProbeClient.Head(url)
+	if err != nil {
+		return false
+	}
+	resp.Body.Close()
+	return resp.StatusCode == nethttp.StatusOK
+}
+
+// resolveBzcdnHost rewrites a bare "sN.bzcdn.net" image URL (see
+// bzcdnBareHostRe) to a live regional edge, HEAD-probing
+// bzcdnRegionSuffixes in order and caching the first one that answers for
+// the rest of this Baozimh instance's lifetime - mirroring the site's own
+// choose_cdn(), which resolves once per page load and reuses the result
+// for every image on it, not once per image. Returns raw unchanged if it
+// isn't a bare bzcdn host (already regional, or a different domain
+// entirely), or if every candidate fails - the caller's normal
+// fetch/retry path then surfaces whatever error the dead original host
+// produces, exactly like before this fix existed.
+func (m *Baozimh) resolveBzcdnHost(raw string) string {
+	u, err := url.Parse(raw)
+	if err != nil {
+		return raw
+	}
+	match := bzcdnBareHostRe.FindStringSubmatch(u.Hostname())
+	if match == nil {
+		return raw
+	}
+	prefix := match[1]
+
+	m.cdnSuffixOnce.Do(func() {
+		for _, suffix := range bzcdnRegionSuffixes {
+			candidate := *u
+			candidate.Host = prefix + suffix
+			if bzcdnProbe(candidate.String()) {
+				m.cdnSuffix = suffix
+				return
+			}
+		}
+	})
+
+	if m.cdnSuffix == "" {
+		return raw
+	}
+	u.Host = prefix + m.cdnSuffix
+	return u.String()
 }
 
 // baozimhNextPartURL returns the href of a reader page's "next part" link

--- a/grabber/baozimh_test.go
+++ b/grabber/baozimh_test.go
@@ -67,6 +67,74 @@ func TestBaozimhChapterNumber(t *testing.T) {
 	}
 }
 
+func TestBaozimhResolveBzcdnHost(t *testing.T) {
+	origProbe := bzcdnProbe
+	defer func() { bzcdnProbe = origProbe }()
+
+	t.Run("non-bzcdn host is left untouched", func(t *testing.T) {
+		bzcdnProbe = func(string) bool {
+			t.Fatal("should not probe a non-bzcdn URL")
+			return false
+		}
+		m := &Baozimh{Grabber: &Grabber{}}
+		raw := "https://www.twmanga.com/comic/foo.html"
+		if got := m.resolveBzcdnHost(raw); got != raw {
+			t.Errorf("resolveBzcdnHost(%q) = %q, want unchanged", raw, got)
+		}
+	})
+
+	t.Run("already-regional host is left untouched", func(t *testing.T) {
+		bzcdnProbe = func(string) bool {
+			t.Fatal("should not probe an already-regional URL")
+			return false
+		}
+		m := &Baozimh{Grabber: &Grabber{}}
+		raw := "https://s2-rsa1-usla.bzcdn.net/scomic/foo/1.jpg"
+		if got := m.resolveBzcdnHost(raw); got != raw {
+			t.Errorf("resolveBzcdnHost(%q) = %q, want unchanged", raw, got)
+		}
+	})
+
+	t.Run("picks the first candidate that answers, and caches it", func(t *testing.T) {
+		var probed []string
+		bzcdnProbe = func(u string) bool {
+			probed = append(probed, u)
+			// the first candidate (-rsa1-usla) fails, the second (-ogsm1-uspho)
+			// answers
+			return strings.Contains(u, "-ogsm1-uspho.bzcdn.net")
+		}
+		m := &Baozimh{Grabber: &Grabber{}}
+
+		raw := "https://s2.bzcdn.net/scomic/foo/1.jpg"
+		want := "https://s2-ogsm1-uspho.bzcdn.net/scomic/foo/1.jpg"
+		if got := m.resolveBzcdnHost(raw); got != want {
+			t.Errorf("resolveBzcdnHost(%q) = %q, want %q", raw, got, want)
+		}
+		if len(probed) != 2 {
+			t.Fatalf("probed %d candidates, want 2 (rsa1 fails, ogsm1 succeeds): %v", len(probed), probed)
+		}
+
+		// a second bare-host URL reuses the cached suffix instead of re-probing
+		raw2 := "https://s2.bzcdn.net/scomic/foo/2.jpg"
+		want2 := "https://s2-ogsm1-uspho.bzcdn.net/scomic/foo/2.jpg"
+		if got := m.resolveBzcdnHost(raw2); got != want2 {
+			t.Errorf("resolveBzcdnHost(%q) = %q, want %q", raw2, got, want2)
+		}
+		if len(probed) != 2 {
+			t.Errorf("second call re-probed instead of reusing the cached suffix: %v", probed)
+		}
+	})
+
+	t.Run("falls back to the original URL when every candidate fails", func(t *testing.T) {
+		bzcdnProbe = func(string) bool { return false }
+		m := &Baozimh{Grabber: &Grabber{}}
+		raw := "https://s1.bzcdn.net/scomic/foo/1.jpg"
+		if got := m.resolveBzcdnHost(raw); got != raw {
+			t.Errorf("resolveBzcdnHost(%q) = %q, want unchanged (all candidates failed)", raw, got)
+		}
+	})
+}
+
 func TestBaozimhNextPartURL(t *testing.T) {
 	tests := []struct {
 		name string


### PR DESCRIPTION
Sonnet 5 here, controlled by elboletaire.

@oralrinse — you wrote the original baozimh grabber (#162, #163), so I'd like your eyes on this before it merges, since it touches the CDN-resolution path and depends on live behavior of baozimh's infrastructure that could shift again.

## The bug

Chapter downloads were failing with `dial tcp 206.168.190.107:443: connect: connection refused` on hosts like `s1.bzcdn.net`/`s2.bzcdn.net`. It looked at first like a dead CDN mirror, but it's not that: **`sN.bzcdn.net` is a placeholder host that was never meant to be requested directly.**

baozimh's own reader page loads `page_runtime_v5.js`, which on every page load runs `choose_cdn()`: it races several regional CDN edges (each `sN` + a region suffix, e.g. `s2-rsa1-usla.bzcdn.net`) and client-side rewrites every `<amp-img src>` to whichever answers first. A scraper that reads the raw HTML (no browser, no JS) only ever sees the bare `sN.bzcdn.net` host, which currently resolves to a single IP that refuses every connection — so every chapter fails, on every series, regardless of which mirror the reader "assigned."

I confirmed this by decoding the site's own obfuscated JS (ran `page_runtime_v5.js` in a Node `vm` sandbox and called its own string-deobfuscation function on the `REQ_DOMAINS` array) rather than guessing, and cross-checked against what a real browser actually requests for the same chapter — it matched exactly.

## The fix

`resolveBzcdnHost` in `grabber/baozimh.go` HEAD-probes the same regional edges the site's own JS tests (`-rsa1-usla`, `-ogsm1-uspho`, `-mha1-nlams`, `-dpa1-cnhk` — all `.bzcdn.net`), and rewrites the bare host to the first one that answers. The result is cached for the lifetime of the download run (one probe, not one per page/chapter), mirroring how the site's own `choose_cdn()` resolves once per page load. If every candidate fails, it falls back to the original URL unchanged — same failure mode as before this fix, nothing gets worse.

## Testing

- New unit test (`TestBaozimhResolveBzcdnHost`) covering: non-bzcdn URLs and already-regional URLs pass through untouched with no probing; picks the first candidate that answers and caches it (verified via probe-call count); falls back to the original URL when every candidate fails.
- Live-verified against two different series/chapters end to end (`go run .` + `tools/verify-cbz`):
  - The originally reported failing chapter — succeeded outright at default settings.
  - A second series/chapter — hit an intermittent `connection reset by peer` on one page under the default `--concurrency-pages 10`, but succeeded cleanly with `--concurrency-pages 1`. This looks like the regional edge enforcing some kind of per-connection/concurrency limit, separate from the bug this PR fixes (the bare host is dead regardless of concurrency; the regional edges are live but may rate-limit bursts). Flagging this rather than burying it — if you've seen this before with baozimh's CDN, or think it's worth a follow-up (e.g. retry backoff, lower default concurrency for this grabber), let me know; I didn't want to expand this PR's scope to guess at a fix for a separately-observed issue.
- `go build ./...`, `go vet ./...`, `gofmt -l .`, and the full `go test ./...` all pass.

## Test plan
- [x] `go build ./...`, `go vet ./...`, `gofmt -l .`, `go test ./...`
- [x] `TestBaozimhResolveBzcdnHost` (new, no network)
- [x] Live: originally-reported failing chapter → `verify-cbz` OK
- [x] Live: second series/chapter → `verify-cbz` OK (with `--concurrency-pages 1`, see note above)